### PR TITLE
ignore static props

### DIFF
--- a/DotNet/DotNetJS/DotNetJS.csproj
+++ b/DotNet/DotNetJS/DotNetJS.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
         <PackageId>DotNetJS</PackageId>
-        <Version>0.5.1</Version>
+        <Version>0.5.2</Version>
         <Authors>Elringus</Authors>
         <PackageDescription>Compile C# project into single-file UMD JavaScript library.</PackageDescription>
         <RepositoryUrl>https://github.com/Elringus/DotNetJS</RepositoryUrl>

--- a/DotNet/Packer.Test/TypesTest.cs
+++ b/DotNet/Packer.Test/TypesTest.cs
@@ -197,4 +197,15 @@ public class TypesTest : ContentTest
         Task.Execute();
         Contains("Method: (t: any) => any");
     }
+
+    [Fact]
+    public void StaticPropertiesAreNotIncluded ()
+    {
+        Data.AddAssembly(
+            "public class Foo { public static string Soo { get; } }" +
+            "[JSInvokable] public static Foo Bar () => default;"
+        );
+        Task.Execute();
+        Matches(@"export class Foo {\s*}");
+    }
 }


### PR DESCRIPTION
This prevents static properties from being included in the emitted type declarations.