### PR TITLE
declare namespaces

### DIFF
--- a/DotNet/DotNetJS.Test/DotNetJS.Test.csproj
+++ b/DotNet/DotNetJS.Test/DotNetJS.Test.csproj
@@ -12,11 +12,11 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.1.0">
+        <PackageReference Include="coverlet.collector" Version="3.1.2">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.msbuild" Version="3.1.0">
+        <PackageReference Include="coverlet.msbuild" Version="3.1.2">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/DotNet/DotNetJS/DotNetJS.csproj
+++ b/DotNet/DotNetJS/DotNetJS.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
         <PackageId>DotNetJS</PackageId>
-        <Version>0.6.0</Version>
+        <Version>0.6.1</Version>
         <Authors>Elringus</Authors>
         <PackageDescription>Compile C# project into single-file UMD JavaScript library.</PackageDescription>
         <RepositoryUrl>https://github.com/Elringus/DotNetJS</RepositoryUrl>
@@ -15,7 +15,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="6.0.1"/>
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="6.0.2"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/DotNet/DotNetJS/DotNetJS.csproj
+++ b/DotNet/DotNetJS/DotNetJS.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
         <PackageId>DotNetJS</PackageId>
-        <Version>0.5.4</Version>
+        <Version>0.6.0</Version>
         <Authors>Elringus</Authors>
         <PackageDescription>Compile C# project into single-file UMD JavaScript library.</PackageDescription>
         <RepositoryUrl>https://github.com/Elringus/DotNetJS</RepositoryUrl>

--- a/DotNet/DotNetJS/DotNetJS.csproj
+++ b/DotNet/DotNetJS/DotNetJS.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
         <PackageId>DotNetJS</PackageId>
-        <Version>0.6.1</Version>
+        <Version>0.6.2</Version>
         <Authors>Elringus</Authors>
         <PackageDescription>Compile C# project into single-file UMD JavaScript library.</PackageDescription>
         <RepositoryUrl>https://github.com/Elringus/DotNetJS</RepositoryUrl>

--- a/DotNet/DotNetJS/build/DotNetJS.targets
+++ b/DotNet/DotNetJS/build/DotNetJS.targets
@@ -27,7 +27,8 @@
                          EntryAssemblyName="$(AssemblyName)"
                          Clean="$(Clean)"
                          EmitSourceMap="$(EmitSourceMap)"
-                         EmitTypes="$(EmitTypes)"/>
+                         EmitTypes="$(EmitTypes)"
+                         NamespacePattern="$(NamespacePattern)"/>
     </Target>
 
 </Project>

--- a/DotNet/Generator.Test/Generator.Test.csproj
+++ b/DotNet/Generator.Test/Generator.Test.csproj
@@ -14,11 +14,11 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.1.0">
+        <PackageReference Include="coverlet.collector" Version="3.1.2">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.msbuild" Version="3.1.0">
+        <PackageReference Include="coverlet.msbuild" Version="3.1.2">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/DotNet/Packer.Test/Mock/MockAssembly.cs
+++ b/DotNet/Packer.Test/Mock/MockAssembly.cs
@@ -33,7 +33,7 @@ public static class MockAssembly
             MetadataReference.CreateFromFile(Path.Combine(coreDir, "System.Runtime.dll")),
             MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
             MetadataReference.CreateFromFile(typeof(JSFunctionAttribute).Assembly.Location),
-            MetadataReference.CreateFromFile(typeof(JSInvokableAttribute).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(JSInvokableAttribute).Assembly.Location)
         };
     }
 

--- a/DotNet/Packer.Test/Packer.Test.csproj
+++ b/DotNet/Packer.Test/Packer.Test.csproj
@@ -10,7 +10,6 @@
         <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.0.0"/>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0"/>
         <PackageReference Include="MSBuild.ProjectCreation" Version="6.3.3"/>
-        <PackageReference Include="TypeScriptModelsGenerator" Version="1.2.0"/>
         <PackageReference Include="xunit" Version="2.4.1"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/DotNet/Packer.Test/Packer.Test.csproj
+++ b/DotNet/Packer.Test/Packer.Test.csproj
@@ -15,11 +15,11 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.1.0">
+        <PackageReference Include="coverlet.collector" Version="3.1.2">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.msbuild" Version="3.1.0">
+        <PackageReference Include="coverlet.msbuild" Version="3.1.2">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/DotNet/Packer.Test/TypesTest.cs
+++ b/DotNet/Packer.Test/TypesTest.cs
@@ -61,7 +61,7 @@ public class TypesTest : ContentTest
     {
         Data.AddAssemblyWithName("foo.dll", "[JSFunction] public static void OnFoo () { }");
         Task.Execute();
-        Contains("export namespace foo.nya {\n    export let OnFoo: () => void;\n}");
+        Contains("export namespace foo {\n    export let OnFoo: () => void;\n}");
     }
 
     [Fact]
@@ -79,8 +79,8 @@ public class TypesTest : ContentTest
     [Fact]
     public void MembersFromDifferentAssembliesWrappedUnderRespectiveNamespaces ()
     {
-        Data.AddAssemblyWithName("foo.dll", "public class Foo { }");
-        Data.AddAssemblyWithName("bar.dll", "[JSInvokable] public static Foo GetFoo () => default;");
+        Data.AddAssemblyWithName("foo.dll", "namespace foo; public class Foo { }");
+        Data.AddAssemblyWithName("bar.dll", "[JSInvokable] public static foo.Foo GetFoo () => default;");
         Task.Execute();
         Contains("export namespace foo {\n    export class Foo {\n    \n}\n}");
         Contains("export namespace bar {\n    export function GetFoo(): foo.Foo;\n}");
@@ -98,8 +98,8 @@ public class TypesTest : ContentTest
     [Fact]
     public void DifferentAssembliesWithSameRootAssignedToDifferentNamespaces ()
     {
-        Data.AddAssemblyWithName("nya.bar.dll", "[JSFunction] public static void Fun () { }");
-        Data.AddAssemblyWithName("nya.foo.dll", "[JSFunction] public static void Foo () { }");
+        Data.AddAssemblyWithName("nya.bar.dll", "[JSInvokable] public static void Fun () { }");
+        Data.AddAssemblyWithName("nya.foo.dll", "[JSInvokable] public static void Foo () { }");
         Task.Execute();
         Contains("export namespace nya.bar {\n    export function Fun(): void;\n}");
         Contains("export namespace nya.foo {\n    export function Foo(): void;\n}");
@@ -113,7 +113,7 @@ public class TypesTest : ContentTest
         var tsArgs = string.Join(", ", nums.Select(n => $"v{Array.IndexOf(nums, n)}: number"));
         Data.AddAssembly($"[JSInvokable] public static void Num ({csArgs}) {{}}");
         Task.Execute();
-        Contains($"Num: ({tsArgs})");
+        Contains($"Num({tsArgs})");
     }
 
     [Fact]

--- a/DotNet/Packer.Test/TypesTest.cs
+++ b/DotNet/Packer.Test/TypesTest.cs
@@ -271,4 +271,25 @@ public class TypesTest : ContentTest
         Matches(@"export enum Foo {\s*A,\s*B\s*}");
         Matches(@"export class Bar {\s*foo\?: asm.Foo;\s*}");
     }
+
+    [Fact]
+    public void WhenInvalidNamespacePatternProvidedExceptionIsThrown ()
+    {
+        Data.AddAssembly("[JSInvokable] public static void Foo () { }");
+        Task.NamespacePattern = "?";
+        Assert.Throws<PackerException>(() => Task.Execute());
+    }
+
+    [Fact]
+    public void NamespacePatternOnlyAffectTypes ()
+    {
+        Data.AddAssemblyWithName("company.product.asm.dll",
+            "public class Foo { }" +
+            "[JSInvokable] public static Foo GetFoo () => default;"
+        );
+        Task.NamespacePattern = @"company\.product\.(\S+)=>$1";
+        Task.Execute();
+        Contains("export namespace asm {\n    export class Foo {\n    }\n}");
+        Contains("export namespace company.product.asm {\n    export function GetFoo(): asm.Foo;\n}");
+    }
 }

--- a/DotNet/Packer.Test/TypesTest.cs
+++ b/DotNet/Packer.Test/TypesTest.cs
@@ -72,7 +72,7 @@ public class TypesTest : ContentTest
             "[JSInvokable] public static Foo GetFoo () => default;"
         );
         Task.Execute();
-        Contains("export namespace asm {\n    export class Foo {\n    \n}\n}");
+        Contains("export namespace asm {\n    export class Foo {\n    }\n}");
         Contains("export namespace asm {\n    export function GetFoo(): asm.Foo;\n}");
     }
 
@@ -82,7 +82,7 @@ public class TypesTest : ContentTest
         Data.AddAssemblyWithName("foo.dll", "namespace foo; public class Foo { }");
         Data.AddAssemblyWithName("bar.dll", "[JSInvokable] public static foo.Foo GetFoo () => default;");
         Task.Execute();
-        Contains("export namespace foo {\n    export class Foo {\n    \n}\n}");
+        Contains("export namespace foo {\n    export class Foo {\n    }\n}");
         Contains("export namespace bar {\n    export function GetFoo(): foo.Foo;\n}");
     }
 
@@ -164,11 +164,11 @@ public class TypesTest : ContentTest
     public void DefinitionIsGeneratedForObjectType ()
     {
         Data.AddAssemblyWithName("asm.dll",
-            "public class Foo { public string Str { get; set; } public int Int { get; set; } }" +
+            "public class Foo { public string S { get; set; } public int I { get; set; } }" +
             "[JSInvokable] public static Foo Method (Foo t) => default;"
         );
         Task.Execute();
-        Matches(@"export class Foo {\s*str: string;\s*int: number;\s*}");
+        Matches(@"export class Foo {\s*s: string;\s*i: number;\s*}");
         Contains("Method(t: asm.Foo): asm.Foo");
     }
 
@@ -182,7 +182,7 @@ public class TypesTest : ContentTest
         );
         Task.Execute();
         Matches(@"export interface Base {\s*foo: asm.Base;\s*}");
-        Matches(@"export class Derived implements Base {\s*foo: asm.Base;\s*}");
+        Matches(@"export class Derived implements asm.Base {\s*foo: asm.Base;\s*}");
         Contains("Method(b: asm.Base): asm.Derived");
     }
 
@@ -213,7 +213,7 @@ public class TypesTest : ContentTest
         Task.Execute();
         Matches(@"export enum Nyam {\s*A,\s*B\s*}");
         Matches(@"export class Foo {\s*nyam: asm.Nyam;\s*}");
-        Matches(@"export class Bar extends Foo {\s*}");
+        Matches(@"export class Bar extends asm.Foo {\s*}");
     }
 
     [Fact]

--- a/DotNet/Packer/AssemblyInspector/AssemblyInspector.cs
+++ b/DotNet/Packer/AssemblyInspector/AssemblyInspector.cs
@@ -13,9 +13,8 @@ namespace Packer;
 internal class AssemblyInspector : IDisposable
 {
     public List<Assembly> Assemblies { get; } = new();
-    public List<Method> InvokableMethods { get; } = new();
-    public List<Method> FunctionMethods { get; } = new();
-    public List<Type> ObjectTypes { get; } = new();
+    public List<Method> Methods { get; } = new();
+    public List<Type> Types { get; } = new();
 
     private readonly List<string> warnings = new();
     private readonly TypeConverter typeConverter = new();
@@ -28,7 +27,7 @@ internal class AssemblyInspector : IDisposable
         foreach (var assemblyPath in assemblyPaths)
             try { InspectAssembly(assemblyPath, context); }
             catch (Exception e) { AddSkippedAssemblyWarning(assemblyPath, e); }
-        ObjectTypes.AddRange(typeConverter.GetObjectTypes());
+        Types.AddRange(typeConverter.GetObjectTypes());
         contextsToDispose.Add(context);
     }
 
@@ -37,10 +36,8 @@ internal class AssemblyInspector : IDisposable
         logger.LogMessage(MessageImportance.Normal, "DotNetJS assembly inspection result:");
         logger.LogMessage(MessageImportance.Normal, JoinLines($"Discovered {Assemblies.Count} assemblies:",
             JoinLines(Assemblies.Select(a => a.Name))));
-        logger.LogMessage(MessageImportance.Normal, JoinLines($"Discovered {InvokableMethods.Count} JS invokable methods:",
-            JoinLines(InvokableMethods.Select(m => m.ToString()))));
-        logger.LogMessage(MessageImportance.Normal, JoinLines($"Discovered {FunctionMethods.Count} JS function methods:",
-            JoinLines(FunctionMethods.Select(m => m.ToString()))));
+        logger.LogMessage(MessageImportance.Normal, JoinLines($"Discovered {Methods.Count} JS methods:",
+            JoinLines(Methods.Select(m => m.ToString()))));
 
         foreach (var warning in warnings)
             logger.LogWarning(warning);
@@ -81,17 +78,19 @@ internal class AssemblyInspector : IDisposable
         foreach (var method in GetStaticMethods(assembly))
         foreach (var attribute in method.CustomAttributes)
             if (attribute.AttributeType.Name == Attributes.Invokable)
-                InvokableMethods.Add(CreateMethod(method));
+                Methods.Add(CreateMethod(method, MethodType.Invokable));
             else if (attribute.AttributeType.Name == Attributes.Function)
-                FunctionMethods.Add(CreateMethod(method));
+                Methods.Add(CreateMethod(method, MethodType.Function));
     }
 
-    private Method CreateMethod (MethodInfo info) => new() {
+    private Method CreateMethod (MethodInfo info, MethodType type) => new() {
         Name = info.Name,
-        Assembly = info.DeclaringType!.Assembly.GetName().Name,
+        Assembly = GetAssemblyName(info.DeclaringType),
+        Namespace = typeConverter.ToNamespace(GetAssemblyName(info.DeclaringType)),
         Arguments = info.GetParameters().Select(CreateArgument).ToArray(),
         ReturnType = typeConverter.ToTypeScript(info.ReturnType),
-        Async = IsAwaitable(info.ReturnType)
+        Async = IsAwaitable(info.ReturnType),
+        Type = type
     };
 
     private Argument CreateArgument (ParameterInfo info) => new() {

--- a/DotNet/Packer/AssemblyInspector/Method.cs
+++ b/DotNet/Packer/AssemblyInspector/Method.cs
@@ -7,13 +7,15 @@ internal record Method
 {
     public string Name { get; init; }
     public string Assembly { get; init; }
+    public string Namespace { get; init; }
     public IReadOnlyList<Argument> Arguments { get; init; }
     public string ReturnType { get; init; }
     public bool Async { get; init; }
+    public MethodType Type { get; init; }
 
     public override string ToString ()
     {
         var args = string.Join(", ", Arguments.Select(a => a.ToString()));
-        return $"{Assembly}.{Name} ({args}) => {ReturnType}";
+        return $"[{Type}] {Assembly}.{Name} ({args}) => {ReturnType}";
     }
 }

--- a/DotNet/Packer/AssemblyInspector/Method.cs
+++ b/DotNet/Packer/AssemblyInspector/Method.cs
@@ -7,7 +7,6 @@ internal record Method
 {
     public string Name { get; init; }
     public string Assembly { get; init; }
-    public string Namespace { get; init; }
     public IReadOnlyList<Argument> Arguments { get; init; }
     public string ReturnType { get; init; }
     public bool Async { get; init; }

--- a/DotNet/Packer/AssemblyInspector/MethodType.cs
+++ b/DotNet/Packer/AssemblyInspector/MethodType.cs
@@ -1,0 +1,7 @@
+﻿namespace Packer;
+
+internal enum MethodType
+{
+    Invokable,
+    Function
+}

--- a/DotNet/Packer/DeclarationGenerator/DeclarationGenerator.cs
+++ b/DotNet/Packer/DeclarationGenerator/DeclarationGenerator.cs
@@ -24,9 +24,8 @@ internal class DeclarationGenerator
 
     public string Generate (AssemblyInspector inspector)
     {
-        var methods = inspector.InvokableMethods.Concat(inspector.FunctionMethods).ToArray();
-        var methodsContent = methodsGenerator.Generate(methods);
-        var objectsContent = typesGenerator.Generate(inspector.ObjectTypes);
+        var methodsContent = methodsGenerator.Generate(inspector.Methods);
+        var objectsContent = typesGenerator.Generate(inspector.Types);
         var runtimeContent = JoinLines(declarations.Select(GenerateForDeclaration), 0);
         return JoinLines(0, runtimeContent, objectsContent, methodsContent) + "\n";
     }
@@ -43,12 +42,10 @@ internal class DeclarationGenerator
 
     private static bool ShouldExportDeclaration (DeclarationFile declaration)
     {
-        switch (declaration.FileName)
-        {
-            case "boot":
-            case "interop": return true;
-            default: return false;
-        }
+        return declaration.FileName switch {
+            "boot" or "interop" => true,
+            _ => false
+        };
     }
 
     private string GetSourceForImportLine (string line)

--- a/DotNet/Packer/DeclarationGenerator/DeclarationGenerator.cs
+++ b/DotNet/Packer/DeclarationGenerator/DeclarationGenerator.cs
@@ -9,8 +9,13 @@ namespace Packer;
 internal class DeclarationGenerator
 {
     private readonly MethodDeclarationGenerator methodsGenerator = new();
-    private readonly TypeDeclarationGenerator typesGenerator = new();
     private readonly List<DeclarationFile> declarations = new();
+    private readonly TypeDeclarationGenerator typesGenerator;
+
+    public DeclarationGenerator (NamespaceBuilder namespaceBuilder)
+    {
+        typesGenerator = new TypeDeclarationGenerator(namespaceBuilder);
+    }
 
     public void LoadDeclarations (string directory)
     {

--- a/DotNet/Packer/DeclarationGenerator/MethodDeclarationGenerator.cs
+++ b/DotNet/Packer/DeclarationGenerator/MethodDeclarationGenerator.cs
@@ -17,7 +17,7 @@ internal class MethodDeclarationGenerator
 
     public string Generate (IEnumerable<Method> sourceMethods)
     {
-        methods = sourceMethods.OrderBy(m => m.Namespace).ToArray();
+        methods = sourceMethods.OrderBy(m => m.Assembly).ToArray();
         for (index = 0; index < methods.Length; index++)
             DeclareMethod();
         return builder.ToString();
@@ -34,19 +34,18 @@ internal class MethodDeclarationGenerator
     private bool ShouldOpenNamespace ()
     {
         if (prevMethod is null) return true;
-        return prevMethod.Namespace != method.Namespace;
+        return prevMethod.Assembly != method.Assembly;
     }
 
     private void OpenNamespace ()
     {
-        var name = method.Namespace;
-        builder.Append($"\nexport namespace {name} {{");
+        builder.Append($"\nexport namespace {method.Assembly} {{");
     }
 
     private bool ShouldCloseNamespace ()
     {
         if (nextMethod is null) return true;
-        return nextMethod.Namespace != method.Namespace;
+        return nextMethod.Assembly != method.Assembly;
     }
 
     private void CloseNamespace ()

--- a/DotNet/Packer/DeclarationGenerator/MethodDeclarationGenerator.cs
+++ b/DotNet/Packer/DeclarationGenerator/MethodDeclarationGenerator.cs
@@ -64,14 +64,19 @@ internal class MethodDeclarationGenerator
     private void AppendInvokable ()
     {
         builder.Append($"\n    export function {method.Name}(");
-        builder.AppendJoin(", ", method.Arguments.Select(a => $"{a.Name}: {a.Type}"));
+        AppendArguments();
         builder.Append($"): {method.ReturnType};");
     }
 
     private void AppendFunction ()
     {
         builder.Append($"\n    export let {method.Name}: (");
-        builder.AppendJoin(", ", method.Arguments.Select(a => $"{a.Name}: {a.Type}"));
+        AppendArguments();
         builder.Append($") => {method.ReturnType};");
+    }
+
+    private void AppendArguments ()
+    {
+        builder.AppendJoin(", ", method.Arguments.Select(a => $"{a.Name}: {a.Type}"));
     }
 }

--- a/DotNet/Packer/DeclarationGenerator/NamespaceBuilder.cs
+++ b/DotNet/Packer/DeclarationGenerator/NamespaceBuilder.cs
@@ -1,0 +1,29 @@
+﻿using System.Text.RegularExpressions;
+
+namespace Packer;
+
+internal class NamespaceBuilder
+{
+    private const string separator = "=>";
+    private readonly string pattern, replace;
+
+    public NamespaceBuilder (string replacePattern = null)
+    {
+        if (!string.IsNullOrEmpty(replacePattern))
+            (pattern, replace) = ParsePattern(replacePattern);
+    }
+
+    public string Build (string assemblyName)
+    {
+        if (pattern is null) return assemblyName;
+        return Regex.Replace(assemblyName, pattern, replace);
+    }
+
+    private static (string pattern, string replace) ParsePattern (string replacePattern)
+    {
+        if (!replacePattern.Contains(separator))
+            throw new PackerException($"Invalid namespace pattern: missing '{separator}'.");
+        var parts = replacePattern.Split(separator);
+        return (parts[0], parts[1]);
+    }
+}

--- a/DotNet/Packer/DeclarationGenerator/TypeConverter.cs
+++ b/DotNet/Packer/DeclarationGenerator/TypeConverter.cs
@@ -15,6 +15,11 @@ internal class TypeConverter
         return ConvertToSimple(type);
     }
 
+    public string ToNamespace (string assemblyName)
+    {
+        return assemblyName;
+    }
+
     public List<Type> GetObjectTypes () => objectTypes.ToList();
 
     private bool ShouldConvertToObject (Type type)
@@ -28,7 +33,8 @@ internal class TypeConverter
     {
         if (IsArray(type)) return $"Array<{ConvertToObject(GetArrayElementType(type))}>";
         CrawlObjectType(type);
-        return type.Name;
+        var space = ToNamespace(GetAssemblyName(type));
+        return $"{space}.{type.Name}";
     }
 
     private string ConvertToSimple (Type type)

--- a/DotNet/Packer/DeclarationGenerator/TypeConverter.cs
+++ b/DotNet/Packer/DeclarationGenerator/TypeConverter.cs
@@ -8,16 +8,17 @@ namespace Packer;
 internal class TypeConverter
 {
     private readonly HashSet<Type> objectTypes = new();
+    private readonly NamespaceBuilder namespaceBuilder;
+
+    public TypeConverter (NamespaceBuilder namespaceBuilder)
+    {
+        this.namespaceBuilder = namespaceBuilder;
+    }
 
     public string ToTypeScript (Type type)
     {
         if (ShouldConvertToObject(type)) return ConvertToObject(type);
         return ConvertToSimple(type);
-    }
-
-    public string ToNamespace (string assemblyName)
-    {
-        return assemblyName;
     }
 
     public List<Type> GetObjectTypes () => objectTypes.ToList();
@@ -34,7 +35,7 @@ internal class TypeConverter
         if (IsArray(type)) return $"Array<{ConvertToObject(GetArrayElementType(type))}>";
         if (IsNullable(type)) return ConvertToObject(GetNullableUnderlyingType(type));
         CrawlObjectType(type);
-        var space = ToNamespace(GetAssemblyName(type));
+        var space = namespaceBuilder.Build(GetAssemblyName(type));
         return $"{space}.{type.Name}";
     }
 

--- a/DotNet/Packer/DeclarationGenerator/TypeConverter.cs
+++ b/DotNet/Packer/DeclarationGenerator/TypeConverter.cs
@@ -32,6 +32,7 @@ internal class TypeConverter
     private string ConvertToObject (Type type)
     {
         if (IsArray(type)) return $"Array<{ConvertToObject(GetArrayElementType(type))}>";
+        if (IsNullable(type)) return ConvertToObject(GetNullableUnderlyingType(type));
         CrawlObjectType(type);
         var space = ToNamespace(GetAssemblyName(type));
         return $"{space}.{type.Name}";
@@ -42,6 +43,7 @@ internal class TypeConverter
         if (type.Name == "Void") return "void";
         if (IsArray(type)) return ToArray(type);
         if (IsAwaitable(type)) return ToPromise(type);
+        if (IsNullable(type)) return ConvertToSimple(GetNullableUnderlyingType(type));
         return ConvertTypeCode(Type.GetTypeCode(type));
     }
 

--- a/DotNet/Packer/DeclarationGenerator/TypeDeclarationGenerator.cs
+++ b/DotNet/Packer/DeclarationGenerator/TypeDeclarationGenerator.cs
@@ -11,7 +11,8 @@ namespace Packer;
 internal class TypeDeclarationGenerator
 {
     private readonly StringBuilder builder = new();
-    private readonly TypeConverter converter = new();
+    private readonly NamespaceBuilder namespaceBuilder;
+    private readonly TypeConverter converter;
 
     private Type type => types[index];
     private Type prevType => index == 0 ? null : types[index - 1];
@@ -19,6 +20,12 @@ internal class TypeDeclarationGenerator
 
     private Type[] types;
     private int index;
+
+    public TypeDeclarationGenerator (NamespaceBuilder namespaceBuilder)
+    {
+        this.namespaceBuilder = namespaceBuilder;
+        converter = new TypeConverter(namespaceBuilder);
+    }
 
     public string Generate (IEnumerable<Type> sourceTypes)
     {
@@ -93,7 +100,7 @@ internal class TypeDeclarationGenerator
     private string GetNamespace (Type type)
     {
         var assemblyName = GetAssemblyName(type);
-        return converter.ToNamespace(assemblyName);
+        return namespaceBuilder.Build(assemblyName);
     }
 
     private void AppendBaseType ()

--- a/DotNet/Packer/LibraryGenerator.cs
+++ b/DotNet/Packer/LibraryGenerator.cs
@@ -31,7 +31,7 @@ internal class LibraryGenerator
     public string Generate (string runtimeJS, string runtimeWasm, string entryName, AssemblyInspector inspector)
     {
         declaredObjects.Clear();
-        var initJS = GenerateInitJS(inspector.InvokableMethods, inspector.FunctionMethods);
+        var initJS = GenerateInitJS(inspector.Methods);
         var dlls = string.Join(", ", inspector.Assemblies.Select(GenerateAssembly));
         return moduleTemplate
             .Replace("%RUNTIME_JS%", runtimeJS)
@@ -46,8 +46,10 @@ internal class LibraryGenerator
         return $"{{ name: '{assembly.Name}', data: '{assembly.Base64}' }}";
     }
 
-    private string GenerateInitJS (IEnumerable<Method> invokable, IEnumerable<Method> functions)
+    private string GenerateInitJS (IReadOnlyCollection<Method> methods)
     {
+        var invokable = methods.Where(m => m.Type == MethodType.Invokable);
+        var functions = methods.Where(m => m.Type == MethodType.Function);
         return JoinLines(
             JoinLines(invokable.Select(GenerateInvokableBinding)),
             JoinLines(functions.Select(GenerateFunctionDeclaration))

--- a/DotNet/Packer/Packer.csproj
+++ b/DotNet/Packer/Packer.csproj
@@ -5,9 +5,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Build.Framework" Version="17.0.0" PrivateAssets="all"/>
-        <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.0.0" PrivateAssets="all"/>
-        <PackageReference Include="System.Reflection.MetadataLoadContext" Version="6.0.0"/>
+        <PackageReference Include="Microsoft.Build.Framework" Version="17.0.0" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.0.0" PrivateAssets="all" />
+        <PackageReference Include="System.Reflection.MetadataLoadContext" Version="6.0.0" />
     </ItemGroup>
 
 </Project>

--- a/DotNet/Packer/Packer.csproj
+++ b/DotNet/Packer/Packer.csproj
@@ -8,7 +8,6 @@
         <PackageReference Include="Microsoft.Build.Framework" Version="17.0.0" PrivateAssets="all"/>
         <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.0.0" PrivateAssets="all"/>
         <PackageReference Include="System.Reflection.MetadataLoadContext" Version="6.0.0"/>
-        <PackageReference Include="TypeScriptModelsGenerator" Version="1.2.0"/>
     </ItemGroup>
 
 </Project>

--- a/DotNet/Packer/Packer.csproj
+++ b/DotNet/Packer/Packer.csproj
@@ -5,9 +5,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Build.Framework" Version="17.0.0" PrivateAssets="all" />
-        <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.0.0" PrivateAssets="all" />
-        <PackageReference Include="System.Reflection.MetadataLoadContext" Version="6.0.0" />
+        <PackageReference Include="Microsoft.Build.Framework" Version="17.0.0" PrivateAssets="all"/>
+        <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.0.0" PrivateAssets="all"/>
+        <PackageReference Include="System.Reflection.MetadataLoadContext" Version="6.0.0"/>
     </ItemGroup>
 
 </Project>

--- a/DotNet/Packer/PublishDotNetJS.cs
+++ b/DotNet/Packer/PublishDotNetJS.cs
@@ -15,6 +15,7 @@ public class PublishDotNetJS : Task
     public bool Clean { get; set; } = true;
     public bool EmitSourceMap { get; set; }
     public bool EmitTypes { get; set; } = true;
+    public string NamespacePattern { get; set; }
 
     public override bool Execute ()
     {
@@ -61,7 +62,7 @@ public class PublishDotNetJS : Task
 
     private AssemblyInspector InspectAssemblies ()
     {
-        var inspector = new AssemblyInspector();
+        var inspector = new AssemblyInspector(new(NamespacePattern));
         inspector.InspectInDirectory(BlazorOutDir);
         inspector.Report(Log);
         return inspector;
@@ -77,7 +78,7 @@ public class PublishDotNetJS : Task
 
     private string GenerateDeclaration (AssemblyInspector inspector)
     {
-        var generator = new DeclarationGenerator();
+        var generator = new DeclarationGenerator(new(NamespacePattern));
         generator.LoadDeclarations(JSDir);
         return generator.Generate(inspector);
     }

--- a/DotNet/Packer/Utilities/TextUtilities.cs
+++ b/DotNet/Packer/Utilities/TextUtilities.cs
@@ -24,6 +24,12 @@ internal static class TextUtilities
 
     public static string JoinLines (int indent, params string[] values) => JoinLines(values, indent);
 
+    public static string ToFirstLower (string value)
+    {
+        if (value.Length == 1) char.ToLowerInvariant(value[0]);
+        return char.ToLowerInvariant(value[0]) + value[1..];
+    }
+
     private static string RemoveEmptyLines (string content)
     {
         return Regex.Replace(content, @"^\s*$\n|\r", string.Empty, RegexOptions.Multiline).Trim();

--- a/DotNet/Packer/Utilities/TypeUtilities.cs
+++ b/DotNet/Packer/Utilities/TypeUtilities.cs
@@ -57,6 +57,11 @@ internal static class TypeUtilities
         return backingField != null;
     }
 
+    public static string GetAssemblyName (Type type)
+    {
+        return type.Assembly.GetName().Name;
+    }
+
     public static bool ShouldIgnoreAssembly (string assemblyPath)
     {
         var assemblyName = Path.GetFileName(assemblyPath);

--- a/DotNet/Packer/Utilities/TypeUtilities.cs
+++ b/DotNet/Packer/Utilities/TypeUtilities.cs
@@ -45,11 +45,6 @@ internal static class TypeUtilities
         return type.GetGenericArguments()[0];
     }
 
-    public static bool IsStatic (PropertyInfo property)
-    {
-        return property.GetAccessors().Any(a => a.IsStatic);
-    }
-
     public static bool IsAutoProperty (PropertyInfo property)
     {
         var backingFieldName = $"<{property.Name}>k__BackingField";

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ For example, to transform `Company.Product.Space` assembly into `Space` namespac
 <PropertyGroup>
     <NamespacePattern>Company\.Product\.(\S+)=>$1</NamespacePattern>
 </PropertyGroup>
-``` 
+```
 
 ## JSON Serializer Options
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,20 @@ For example, following configuration will preserve build artifacts, emit source 
 </Project>
 ```
 
+## Namespace Pattern
+
+When `EmitTypes` is enabled, the generated Type Script object definitions are wrapped under namespace equal to the corresponding assembly name of the .NET types.
+
+To override the namespace, specify `NamespacePattern` build property containing `pattern` and `replacement` arguments for [Regex.Replace](https://docs.microsoft.com/en-us/dotnet/api/system.text.regularexpressions.regex.replace?view=net-6.0#system-text-regularexpressions-regex-replace(system-string-system-string-system-string)) method separated by `=>`.
+
+For example, to transform `Company.Product.Space` assembly into `Space` namespace, use the following pattern:
+
+```xml
+<PropertyGroup>
+    <NamespacePattern>Company\.Product\.(\S+)=>$1</NamespacePattern>
+</PropertyGroup>
+``` 
+
 ## JSON Serializer Options
 
 To override default JSON serializer options used for marshalling the interop data, use `JS.Runtime.ConfigureJson` method before the program entry point is invoked. For example, below will add `JsonStringEnumConverter` converter to allow serializing enums via strings:


### PR DESCRIPTION
Group object declarations under namespaces in type script. The namespace is equal to assembly name by default, but can be modified via `NamespacePattern` build property (see readme for more info).

C# methods will be declared as functions, JS callbacks as `let` members with the method signature.

Object types were previously generated at the root, so this is a breaking change (when using type script).