### PR TITLE
add int array types

### DIFF
--- a/DotNet/DotNetJS/DotNetJS.csproj
+++ b/DotNet/DotNetJS/DotNetJS.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
         <PackageId>DotNetJS</PackageId>
-        <Version>0.9.2</Version>
+        <Version>0.10.0</Version>
         <Authors>Elringus</Authors>
         <PackageDescription>Compile C# project into single-file UMD JavaScript library.</PackageDescription>
         <RepositoryUrl>https://github.com/Elringus/DotNetJS</RepositoryUrl>

--- a/DotNet/Packer.Test/DeclarationTest.cs
+++ b/DotNet/Packer.Test/DeclarationTest.cs
@@ -234,6 +234,14 @@ public class DeclarationTest : ContentTest
     }
 
     [Fact]
+    public void ByteArrayTranslatedToUint8Array ()
+    {
+        AddAssembly(With("[JSInvokable] public static void Foo (byte[] bar) {}"));
+        Task.Execute();
+        Contains("Foo(bar: Uint8Array): void");
+    }
+
+    [Fact]
     public void DefinitionIsGeneratedForObjectType ()
     {
         AddAssembly(

--- a/DotNet/Packer.Test/DeclarationTest.cs
+++ b/DotNet/Packer.Test/DeclarationTest.cs
@@ -234,11 +234,23 @@ public class DeclarationTest : ContentTest
     }
 
     [Fact]
-    public void ByteArrayTranslatedToUint8Array ()
+    public void IntArraysTranslatedToRelatedTypes ()
     {
-        AddAssembly(With("[JSInvokable] public static void Foo (byte[] bar) {}"));
+        AddAssembly(
+            With("[JSInvokable] public static void Uint8 (byte[] foo) {}"),
+            With("[JSInvokable] public static void Int8 (sbyte[] foo) {}"),
+            With("[JSInvokable] public static void Uint16 (ushort[] foo) {}"),
+            With("[JSInvokable] public static void Int16 (short[] foo) {}"),
+            With("[JSInvokable] public static void Uint32 (uint[] foo) {}"),
+            With("[JSInvokable] public static void Int32 (int[] foo) {}")
+        );
         Task.Execute();
-        Contains("Foo(bar: Uint8Array): void");
+        Contains("Uint8(foo: Uint8Array): void");
+        Contains("Int8(foo: Int8Array): void");
+        Contains("Uint16(foo: Uint16Array): void");
+        Contains("Int16(foo: Int16Array): void");
+        Contains("Uint32(foo: Uint32Array): void");
+        Contains("Int32(foo: Int32Array): void");
     }
 
     [Fact]

--- a/DotNet/Packer/DeclarationGenerator/TypeConverter.cs
+++ b/DotNet/Packer/DeclarationGenerator/TypeConverter.cs
@@ -50,6 +50,7 @@ internal class TypeConverter
     private string ToArray (Type type)
     {
         var elementType = GetArrayElementType(type);
+        if (Type.GetTypeCode(elementType) == TypeCode.Byte) return "Uint8Array";
         return $"Array<{ConvertToSimple(elementType)}>";
     }
 

--- a/DotNet/Packer/DeclarationGenerator/TypeConverter.cs
+++ b/DotNet/Packer/DeclarationGenerator/TypeConverter.cs
@@ -50,13 +50,15 @@ internal class TypeConverter
     private string ToArray (Type type)
     {
         var elementType = GetArrayElementType(type);
-        if (Type.GetTypeCode(elementType) == TypeCode.Byte) return "Uint8Array";
-        if (Type.GetTypeCode(elementType) == TypeCode.SByte) return "Int8Array";
-        if (Type.GetTypeCode(elementType) == TypeCode.UInt16) return "Uint16Array";
-        if (Type.GetTypeCode(elementType) == TypeCode.Int16) return "Int16Array";
-        if (Type.GetTypeCode(elementType) == TypeCode.UInt32) return "Uint32Array";
-        if (Type.GetTypeCode(elementType) == TypeCode.Int32) return "Int32Array";
-        return $"Array<{ConvertToSimple(elementType)}>";
+        return Type.GetTypeCode(elementType) switch {
+            TypeCode.Byte => "Uint8Array",
+            TypeCode.SByte => "Int8Array",
+            TypeCode.UInt16 => "Uint16Array",
+            TypeCode.Int16 => "Int16Array",
+            TypeCode.UInt32 => "Uint32Array",
+            TypeCode.Int32 => "Int32Array",
+            _ => $"Array<{ConvertToSimple(elementType)}>"
+        };
     }
 
     private string ToPromise (Type type)

--- a/DotNet/Packer/DeclarationGenerator/TypeConverter.cs
+++ b/DotNet/Packer/DeclarationGenerator/TypeConverter.cs
@@ -51,6 +51,11 @@ internal class TypeConverter
     {
         var elementType = GetArrayElementType(type);
         if (Type.GetTypeCode(elementType) == TypeCode.Byte) return "Uint8Array";
+        if (Type.GetTypeCode(elementType) == TypeCode.SByte) return "Int8Array";
+        if (Type.GetTypeCode(elementType) == TypeCode.UInt16) return "Uint16Array";
+        if (Type.GetTypeCode(elementType) == TypeCode.Int16) return "Int16Array";
+        if (Type.GetTypeCode(elementType) == TypeCode.UInt32) return "Uint32Array";
+        if (Type.GetTypeCode(elementType) == TypeCode.Int32) return "Int32Array";
         return $"Array<{ConvertToSimple(elementType)}>";
     }
 


### PR DESCRIPTION
This will transform C# numeric arrays (byte, sbyte, int, uint, etc) into related TypeScript types (Uint8Array, Int32Array, etc) instead of `Array<number>`.