### PR TITLE
fix function task codegen

### DIFF
--- a/DotNet/DotNetJS/DotNetJS.csproj
+++ b/DotNet/DotNetJS/DotNetJS.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
         <PackageId>DotNetJS</PackageId>
-        <Version>0.10.0</Version>
+        <Version>0.10.1</Version>
         <Authors>Elringus</Authors>
         <PackageDescription>Compile C# project into single-file UMD JavaScript library.</PackageDescription>
         <RepositoryUrl>https://github.com/Elringus/DotNetJS</RepositoryUrl>

--- a/DotNet/Generator.Test/TestData.cs
+++ b/DotNet/Generator.Test/TestData.cs
@@ -30,7 +30,7 @@ public static partial class Foo
 namespace File.Scoped;
 public static partial class Foo
 {
-    private static partial Task BarAsync (string a, int b) => JS.InvokeAsync(""dotnet.File.Scoped.BarAsync"", a, b);
+    private static partial Task BarAsync (string a, int b) => JS.InvokeAsync(""dotnet.File.Scoped.BarAsync"", a, b).AsTask();
 }"
         },
         new object[] {
@@ -45,7 +45,7 @@ public static partial class Foo
 namespace File.Scoped;
 public static partial class Foo
 {
-    private static partial Task<string?> BarAsync () => JS.InvokeAsync<string?>(""dotnet.File.Scoped.BarAsync"");
+    private static partial Task<string?> BarAsync () => JS.InvokeAsync<string?>(""dotnet.File.Scoped.BarAsync"").AsTask();
 }"
         },
         new object[] {

--- a/DotNet/Generator.Test/TestData.cs
+++ b/DotNet/Generator.Test/TestData.cs
@@ -35,6 +35,21 @@ public static partial class Foo
         },
         new object[] {
             @"
+namespace File.Scoped;
+public static partial class Foo
+{
+    [JSFunction]
+    private static partial Task<string?> BarAsync ();
+}",
+            @"
+namespace File.Scoped;
+public static partial class Foo
+{
+    private static partial Task<string?> BarAsync () => JS.InvokeAsync<string?>(""dotnet.File.Scoped.BarAsync"");
+}"
+        },
+        new object[] {
+            @"
 namespace Classic
 {
     partial class Foo

--- a/DotNet/Generator/GeneratedMethod.cs
+++ b/DotNet/Generator/GeneratedMethod.cs
@@ -50,7 +50,8 @@ namespace Generator
             return
                 returnType is "void" ? "Invoke" :
                 returnType is "ValueTask" || returnType is "Task" ? "InvokeAsync" :
-                returnType.Contains("Task") ? $"InvokeAsync<{returnType.Substring(10, returnType.Length - 11)}>" :
+                returnType.StartsWith("Task<") ? $"InvokeAsync<{returnType.Substring(5, returnType.Length - 6)}>" :
+                returnType.StartsWith("ValueTask<") ? $"InvokeAsync<{returnType.Substring(10, returnType.Length - 11)}>" :
                 $"Invoke<{returnType}>";
         }
 

--- a/DotNet/Generator/GeneratedMethod.cs
+++ b/DotNet/Generator/GeneratedMethod.cs
@@ -41,7 +41,8 @@ namespace Generator
         {
             var invokeMethod = GetInvokeMethod();
             var invokeParameters = GetInvokeParameters(@namespace);
-            return $"JS.{invokeMethod}({invokeParameters})";
+            var convertTask = syntax.ReturnType.ToString().StartsWith("Task") ? ".AsTask()" : "";
+            return $"JS.{invokeMethod}({invokeParameters}){convertTask}";
         }
 
         private string GetInvokeMethod ()


### PR DESCRIPTION
This fixes code generated for `[JSFunction]` which has `Task` return type.