### PR TITLE
support nullable args

### DIFF
--- a/DotNet/DotNetJS/DotNetJS.csproj
+++ b/DotNet/DotNetJS/DotNetJS.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
         <PackageId>DotNetJS</PackageId>
-        <Version>0.10.1</Version>
+        <Version>0.11.0</Version>
         <Authors>Elringus</Authors>
         <PackageDescription>Compile C# project into single-file UMD JavaScript library.</PackageDescription>
         <RepositoryUrl>https://github.com/Elringus/DotNetJS</RepositoryUrl>

--- a/DotNet/Packer.Test/DeclarationTest.cs
+++ b/DotNet/Packer.Test/DeclarationTest.cs
@@ -336,9 +336,13 @@ public class DeclarationTest : ContentTest
     [Fact]
     public void NullableMethodArgumentsHaveOptionalModificator ()
     {
-        AddAssembly(With("[JSInvokable] public static void Foo (string? bar, byte[]? nya) { }"));
+        AddAssembly(
+            With("[JSInvokable] public static void Foo (string? bar) { }"),
+            With("[JSFunction] public static void Fun (byte[]? nya) { }")
+        );
         Task.Execute();
-        Contains("export function Foo(bar?: string, nya?: Uint8Array): void;");
+        Contains("export function Foo(bar?: string): void;");
+        Contains("export let Fun: (nya?: Uint8Array) => void;");
     }
 
     [Fact]
@@ -347,12 +351,12 @@ public class DeclarationTest : ContentTest
         AddAssembly(
             With("[JSInvokable] public static string? Foo () => default;"),
             With("[JSInvokable] public static Task<byte[]?> Bar () => default;"),
-            With("[JSInvokable] public static ValueTask<List<string>?> Nya () => default;")
+            With("[JSFunction] public static ValueTask<List<string>?> Nya () => default;")
         );
         Task.Execute();
         Contains("export function Foo(): string | undefined;");
         Contains("export function Bar(): Promise<Uint8Array | undefined>;");
-        Contains("export function Nya(): Promise<Array<string> | undefined>;");
+        Contains("export let Nya: () => Promise<Array<string> | undefined>;");
     }
 
     [Fact]
@@ -377,6 +381,14 @@ public class DeclarationTest : ContentTest
         Task.Execute();
         Matches(@"export enum Foo {\s*A,\s*B\s*}");
         Matches(@"export class Bar {\s*foo\?: n.Foo;\s*}");
+    }
+
+    [Fact]
+    public void NullableEventTypesHaveOptionalModificator ()
+    {
+        AddAssembly(With("[JSEvent] public static void OnFoo (string? bar) { }"));
+        Task.Execute();
+        Contains("export const OnFoo: Event<[string?]>;");
     }
 
     [Fact]

--- a/DotNet/Packer.Test/DeclarationTest.cs
+++ b/DotNet/Packer.Test/DeclarationTest.cs
@@ -338,11 +338,11 @@ public class DeclarationTest : ContentTest
     {
         AddAssembly(
             With("[JSInvokable] public static void Foo (string? bar) { }"),
-            With("[JSFunction] public static void Fun (byte[]? nya) { }")
+            With("[JSFunction] public static void Fun (int? nya) { }")
         );
         Task.Execute();
         Contains("export function Foo(bar?: string): void;");
-        Contains("export let Fun: (nya?: Uint8Array) => void;");
+        Contains("export let Fun: (nya?: number) => void;");
     }
 
     [Fact]

--- a/DotNet/Packer.Test/DeclarationTest.cs
+++ b/DotNet/Packer.Test/DeclarationTest.cs
@@ -334,6 +334,28 @@ public class DeclarationTest : ContentTest
     }
 
     [Fact]
+    public void NullableMethodArgumentsHaveOptionalModificator ()
+    {
+        AddAssembly(With("[JSInvokable] public static void Foo (string? bar, byte[]? nya) { }"));
+        Task.Execute();
+        Contains("export function Foo(bar?: string, nya?: Uint8Array): void;");
+    }
+
+    [Fact]
+    public void NullableMethodReturnTypesUnionWithUndefined ()
+    {
+        AddAssembly(
+            With("[JSInvokable] public static string? Foo () => default;"),
+            With("[JSInvokable] public static Task<byte[]?> Bar () => default;"),
+            With("[JSInvokable] public static ValueTask<List<string>?> Nya () => default;")
+        );
+        Task.Execute();
+        Contains("export function Foo(): string | undefined;");
+        Contains("export function Bar(): Promise<Uint8Array | undefined>;");
+        Contains("export function Nya(): Promise<Array<string> | undefined>;");
+    }
+
+    [Fact]
     public void NullablePropertiesHaveOptionalModificator ()
     {
         AddAssembly(

--- a/DotNet/Packer/AssemblyInspector/Argument.cs
+++ b/DotNet/Packer/AssemblyInspector/Argument.cs
@@ -4,6 +4,7 @@ internal record Argument
 {
     public string Name { get; init; } = null!;
     public string Type { get; init; } = null!;
+    public bool Nullable { get; init; }
 
     public override string ToString () => $"{Name}: {Type}";
 }

--- a/DotNet/Packer/AssemblyInspector/AssemblyInspector.cs
+++ b/DotNet/Packer/AssemblyInspector/AssemblyInspector.cs
@@ -100,13 +100,15 @@ internal class AssemblyInspector : IDisposable
         Namespace = spaceBuilder.Build(info.DeclaringType),
         Arguments = info.GetParameters().Select(CreateArgument).ToArray(),
         ReturnType = typeConverter.ToTypeScript(info.ReturnType),
+        ReturnNullable = IsNullable(info),
         Async = IsAwaitable(info.ReturnType),
         Type = type
     };
 
     private Argument CreateArgument (ParameterInfo info) => new() {
         Name = info.Name == "function" ? "fn" : info.Name!,
-        Type = typeConverter.ToTypeScript(info.ParameterType)
+        Type = typeConverter.ToTypeScript(info.ParameterType),
+        Nullable = IsNullable(info)
     };
 
     private static string ReadBase64 (string filePath)

--- a/DotNet/Packer/AssemblyInspector/Method.cs
+++ b/DotNet/Packer/AssemblyInspector/Method.cs
@@ -10,6 +10,7 @@ internal record Method
     public string Namespace { get; init; } = null!;
     public IReadOnlyList<Argument> Arguments { get; init; } = null!;
     public string ReturnType { get; init; } = null!;
+    public bool ReturnNullable { get; init; }
     public bool Async { get; init; }
     public MethodType Type { get; init; }
 

--- a/DotNet/Packer/DeclarationGenerator/MethodDeclarationGenerator.cs
+++ b/DotNet/Packer/DeclarationGenerator/MethodDeclarationGenerator.cs
@@ -57,31 +57,34 @@ internal class MethodDeclarationGenerator
     private void DeclareInvokable ()
     {
         builder.Append($"\n    export function {method.Name}(");
-        AppendArguments();
-        builder.Append($"): {method.ReturnType};");
+        builder.AppendJoin(", ", method.Arguments.Select(BuildArgumentDeclaration));
+        builder.Append($"): {BuildReturnDeclaration(method)};");
     }
 
     private void DeclareFunction ()
     {
         builder.Append($"\n    export let {method.Name}: (");
-        AppendArguments();
-        builder.Append($") => {method.ReturnType};");
+        builder.AppendJoin(", ", method.Arguments.Select(BuildArgumentDeclaration));
+        builder.Append($") => {BuildReturnDeclaration(method)};");
     }
 
     private void DeclareEvent ()
     {
         builder.Append($"\n    export const {method.Name}: Event<[");
-        AppendArgumentTypes();
+        builder.AppendJoin(", ", method.Arguments.Select(a => $"{a.Type}{(a.Nullable ? "?" : "")}"));
         builder.Append("]>;");
     }
 
-    private void AppendArguments ()
+    private string BuildArgumentDeclaration (Argument arg)
     {
-        builder.AppendJoin(", ", method.Arguments.Select(a => $"{a.Name}: {a.Type}"));
+        return $"{arg.Name}{(arg.Nullable ? "?" : "")}: {arg.Type}";
     }
 
-    private void AppendArgumentTypes ()
+    private string BuildReturnDeclaration (Method method)
     {
-        builder.AppendJoin(", ", method.Arguments.Select(a => a.Type));
+        if (!method.ReturnNullable) return method.ReturnType;
+        if (!method.Async) return $"{method.ReturnType} | undefined";
+        var insertIndex = method.ReturnType.Length - 1;
+        return method.ReturnType.Insert(insertIndex, " | undefined");
     }
 }

--- a/DotNet/Packer/Utilities/TypeUtilities.cs
+++ b/DotNet/Packer/Utilities/TypeUtilities.cs
@@ -33,6 +33,21 @@ internal static class TypeUtilities
         return context.ReadState == NullabilityState.Nullable;
     }
 
+    public static bool IsNullable (ParameterInfo parameter)
+    {
+        if (IsNullable(parameter.ParameterType)) return true;
+        var context = new NullabilityInfoContext().Create(parameter);
+        return context.ReadState == NullabilityState.Nullable;
+    }
+
+    public static bool IsNullable (MethodInfo method)
+    {
+        if (IsNullable(method.ReturnParameter)) return true;
+        if (!IsAwaitable(method.ReturnType)) return false;
+        var context = new NullabilityInfoContext().Create(method.ReturnParameter);
+        return context.GenericTypeArguments.FirstOrDefault()?.ReadState == NullabilityState.Nullable;
+    }
+
     public static bool IsNullable (Type type)
     {
         return type.IsGenericType &&


### PR DESCRIPTION
This will make C# method arguments and return types with nullable annotation translate to similar concept in TypeScript. Eg:

```csharp
Task<string?> Foo (string? bar)
```

```ts
function Foo(bar?: string): Promise<string | undefined>
```
