### PR TITLE
strip user agent usage

### DIFF
--- a/DotNet/DotNetJS/DotNetJS.csproj
+++ b/DotNet/DotNetJS/DotNetJS.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
         <PackageId>DotNetJS</PackageId>
-        <Version>0.13.3</Version>
+        <Version>0.13.4</Version>
         <Authors>Elringus</Authors>
         <PackageDescription>Compile C# project into single-file UMD JavaScript library.</PackageDescription>
         <RepositoryUrl>https://github.com/Elringus/DotNetJS</RepositoryUrl>

--- a/JavaScript/dotnet-runtime/native/dotnet.js
+++ b/JavaScript/dotnet-runtime/native/dotnet.js
@@ -4083,7 +4083,7 @@ var Module = (function () {
                     this.isChromium = false;
                     if (globalThis.navigator) {
                         var nav = globalThis.navigator;
-                        if (nav.userAgentData && nav.userAgentData.brands) {this.isChromium = nav.userAgentData.brands.some(i => i.brand == "Chromium");} else if (globalThis.navigator.userAgent) {this.isChromium = nav.userAgent.includes("Chrome");}
+                        if (nav.userAgentData && nav.userAgentData.brands) {this.isChromium = nav.userAgentData.brands.some(i => i.brand == "Chromium");} else if ({}) {this.isChromium = nav.userAgent.includes("Chrome");}
                     }
                     this._empty_string = "";
                     this._empty_string_ptr = 0;

--- a/JavaScript/dotnet-runtime/scripts/compile-runtime.sh
+++ b/JavaScript/dotnet-runtime/scripts/compile-runtime.sh
@@ -14,4 +14,5 @@ cp -f native/runtime/artifacts/bin/native/net6.0-Browser-Release-wasm/dotnet.was
 sed -i "s/require([^)]*./{}/g" native/dotnet.js
 sed -i "s/performance.now()/0/g" native/dotnet.js
 sed -i "s/console.debug(\"mono_wasm_runtime_ready.\+)/{}/g" native/dotnet.js
+sed -i "s/globalThis.navigator.userAgent/{}/g" native/dotnet.js
 read -r -p "Press Enter key to exit..."


### PR DESCRIPTION
Remove `navigator.userAgent` from auto-generated .NET wrapper to prevent warnings in chrome.