### PR TITLE
mute generated warnings

### DIFF
--- a/DotNet/DotNetJS/DotNetJS.csproj
+++ b/DotNet/DotNetJS/DotNetJS.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
         <PackageId>DotNetJS</PackageId>
-        <Version>0.13.7</Version>
+        <Version>0.13.8</Version>
         <Authors>Elringus</Authors>
         <PackageDescription>Compile C# project into single-file UMD JavaScript library.</PackageDescription>
         <RepositoryUrl>https://github.com/Elringus/DotNetJS</RepositoryUrl>

--- a/DotNet/Generator.Test/TestData.cs
+++ b/DotNet/Generator.Test/TestData.cs
@@ -12,11 +12,16 @@ partial class Foo
     [JSFunction]
     partial void Bar ();
 }",
-            @"#nullable enable
+            @"
+#nullable enable
+#pragma warning disable
 partial class Foo
 {
     partial void Bar () => JS.Invoke(""dotnet.Bindings.Bar"");
-}"
+}
+#pragma warning restore
+#nullable restore
+"
         },
         new object[] {
             @"
@@ -26,12 +31,17 @@ public static partial class Foo
     [JSFunction]
     private static partial Task BarAsync (string a, int b);
 }",
-            @"#nullable enable
+            @"
+#nullable enable
+#pragma warning disable
 namespace File.Scoped;
 public static partial class Foo
 {
     private static partial Task BarAsync (string a, int b) => JS.InvokeAsync(""dotnet.File.Scoped.BarAsync"", new object[] { a, b }).AsTask();
-}"
+}
+#pragma warning restore
+#nullable restore
+"
         },
         new object[] {
             @"
@@ -41,12 +51,17 @@ public static partial class Foo
     [JSFunction]
     private static partial Task<string?> BarAsync ();
 }",
-            @"#nullable enable
+            @"
+#nullable enable
+#pragma warning disable
 namespace File.Scoped;
 public static partial class Foo
 {
     private static partial Task<string?> BarAsync () => JS.InvokeAsync<string?>(""dotnet.File.Scoped.BarAsync"").AsTask();
-}"
+}
+#pragma warning restore
+#nullable restore
+"
         },
         new object[] {
             @"
@@ -60,7 +75,9 @@ namespace Classic
         partial ValueTask<DateTime> GetTimeAsync (DateTime time);
     }
 }",
-            @"#nullable enable
+            @"
+#nullable enable
+#pragma warning disable
 namespace Classic
 {
 partial class Foo
@@ -68,7 +85,10 @@ partial class Foo
     partial DateTime GetTime (DateTime time) => JS.Invoke<DateTime>(""dotnet.Classic.GetTime"", new object[] { time });
     partial ValueTask<DateTime> GetTimeAsync (DateTime time) => JS.InvokeAsync<DateTime>(""dotnet.Classic.GetTimeAsync"", new object[] { time });
 }
-}"
+}
+#pragma warning restore
+#nullable restore
+"
         },
         new object[] {
             @"
@@ -83,13 +103,18 @@ namespace Foo.Bar.Nya;
         [JSFunction]
         private static partial void OnFun (Nya nya);
     }",
-            @"#nullable enable
+            @"
+#nullable enable
+#pragma warning disable
 using System;
 namespace Foo.Bar.Nya;
 public partial class Nya
 {
     private static partial void OnFun (Nya nya) => JS.Invoke(""dotnet.Nya.OnFun"", new object[] { nya });
-}"
+}
+#pragma warning restore
+#nullable restore
+"
         }
     };
 
@@ -101,11 +126,16 @@ partial class Foo
     [JSEvent]
     partial void OnBar ();
 }",
-            @"#nullable enable
+            @"
+#nullable enable
+#pragma warning disable
 partial class Foo
 {
     partial void OnBar () => JS.Invoke(""dotnet.Bindings.OnBar.broadcast"");
-}"
+}
+#pragma warning restore
+#nullable restore
+"
         },
         new object[] {
             @"
@@ -115,12 +145,17 @@ public static partial class Foo
     [JSEvent]
     public static partial void OnBar (string a, int b);
 }",
-            @"#nullable enable
+            @"
+#nullable enable
+#pragma warning disable
 namespace Space;
 public static partial class Foo
 {
     public static partial void OnBar (string a, int b) => JS.Invoke(""dotnet.Space.OnBar.broadcast"", new object[] { a, b });
-}"
+}
+#pragma warning restore
+#nullable restore
+"
         }
     };
 }

--- a/DotNet/Generator/GeneratedClass.cs
+++ b/DotNet/Generator/GeneratedClass.cs
@@ -18,13 +18,21 @@ namespace Generator
 
         public string EmitSource (Compilation compilation)
         {
-            return "#nullable enable\n" +
-                   EmitImport() +
-                   WrapNamespace(
-                       EmitHeader() +
-                       EmitMethods(compilation) +
-                       EmitFooter()
-                   );
+            return WrapDefines(
+                EmitImport() +
+                WrapNamespace(
+                    EmitHeader() +
+                    EmitMethods(compilation) +
+                    EmitFooter()
+                )
+            );
+        }
+
+        private string WrapDefines (string source)
+        {
+            return "\n#nullable enable\n#pragma warning disable\n" +
+                   source +
+                   "\n#pragma warning restore\n#nullable restore\n";
         }
 
         private string EmitImport ()


### PR DESCRIPTION
Mute compiler warnings in auto-generated C# files; temp solution for #72.