### PR TITLE
improve sideloading binaries

### DIFF
--- a/DotNet/DotNetJS.Test/DotNetJS.Test.csproj
+++ b/DotNet/DotNetJS.Test/DotNetJS.Test.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1"/>
         <PackageReference Include="xunit" Version="2.4.2"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/DotNet/DotNetJS.Test/DotNetJS.Test.csproj
+++ b/DotNet/DotNetJS.Test/DotNetJS.Test.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2"/>
         <PackageReference Include="xunit" Version="2.4.2"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/DotNet/DotNetJS/DotNetJS.csproj
+++ b/DotNet/DotNetJS/DotNetJS.csproj
@@ -15,7 +15,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="6.0.9"/>
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="6.0.8"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/DotNet/DotNetJS/DotNetJS.csproj
+++ b/DotNet/DotNetJS/DotNetJS.csproj
@@ -15,7 +15,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="6.0.8"/>
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="6.0.9"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/DotNet/DotNetJS/DotNetJS.csproj
+++ b/DotNet/DotNetJS/DotNetJS.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
         <PackageId>DotNetJS</PackageId>
-        <Version>0.15.1</Version>
+        <Version>0.16.0</Version>
         <Authors>Elringus</Authors>
         <PackageDescription>Compile C# project into single-file UMD JavaScript library.</PackageDescription>
         <RepositoryUrl>https://github.com/Elringus/DotNetJS</RepositoryUrl>

--- a/DotNet/DotNetJS/build/DotNetJS.targets
+++ b/DotNet/DotNetJS/build/DotNetJS.targets
@@ -20,7 +20,7 @@
     <UsingTask TaskName="DotNetJS.Packer.PublishDotNetJS" AssemblyFile="$(PackerAssembly)"/>
 
     <Target Name="PublishDotNetJS" AfterTargets="Publish">
-        <PublishDotNetJS BaseDir="$(BaseOutputPath)"
+        <PublishDotNetJS PublishDir="$(BaseOutputPath)"
                          BlazorOutDir="$(OutDir)/publish/wwwroot/_framework"
                          JSDir="$(JSDir)"
                          WasmFile="$(WasmFile)"

--- a/DotNet/Generator.Test/Generator.Test.csproj
+++ b/DotNet/Generator.Test/Generator.Test.csproj
@@ -8,7 +8,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.CodeAnalysis" Version="4.2.0"/>
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" Version="1.1.1"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2"/>
         <PackageReference Include="xunit" Version="2.4.2"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/DotNet/Generator.Test/Generator.Test.csproj
+++ b/DotNet/Generator.Test/Generator.Test.csproj
@@ -6,9 +6,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis" Version="4.3.1"/>
+        <PackageReference Include="Microsoft.CodeAnalysis" Version="4.2.0"/>
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" Version="1.1.1"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1"/>
         <PackageReference Include="xunit" Version="2.4.2"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/DotNet/Generator.Test/Generator.Test.csproj
+++ b/DotNet/Generator.Test/Generator.Test.csproj
@@ -6,9 +6,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis" Version="4.2.0"/>
+        <PackageReference Include="Microsoft.CodeAnalysis" Version="4.3.1"/>
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" Version="1.1.1"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2"/>
         <PackageReference Include="xunit" Version="2.4.2"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/DotNet/Generator/Generator.csproj
+++ b/DotNet/Generator/Generator.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.2.0" PrivateAssets="all"/>
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.1" PrivateAssets="all"/>
     </ItemGroup>
 
 </Project>

--- a/DotNet/Generator/Generator.csproj
+++ b/DotNet/Generator/Generator.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.1" PrivateAssets="all"/>
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.2.0" PrivateAssets="all"/>
     </ItemGroup>
 
 </Project>

--- a/DotNet/Packer.Test/LibraryTest.cs
+++ b/DotNet/Packer.Test/LibraryTest.cs
@@ -19,7 +19,7 @@ public class LibraryTest : ContentTest
         AddAssembly("Foo.dll");
         Task.EmbedBinaries = false;
         Task.Execute();
-        Contains("exports.bootUris = {");
+        Contains("exports.getBootUris = () => ({");
         Contains("wasm: \"dotnet.wasm\"");
         Contains("entryAssembly: \"Foo.dll\"");
         Contains("assemblies: [");

--- a/DotNet/Packer.Test/LibraryTest.cs
+++ b/DotNet/Packer.Test/LibraryTest.cs
@@ -14,6 +14,20 @@ public class LibraryTest : ContentTest
     }
 
     [Fact]
+    public void WhenEmbedBinariesDisabledLibraryExportsBootUris ()
+    {
+        AddAssembly("Foo.dll");
+        Task.EmbedBinaries = false;
+        Task.Execute();
+        Contains("exports.bootUris = {");
+        Contains("wasm: \"dotnet.wasm\"");
+        Contains("entryAssembly: \"Foo.dll\"");
+        Contains("assemblies: [");
+        Contains("Foo.dll");
+        Contains("DotNetJS.dll");
+    }
+
+    [Fact]
     public void LibraryExportsNamespaceObject ()
     {
         AddAssembly(With("Foo", "[JSInvokable] public static void Bar () { }"));

--- a/DotNet/Packer.Test/Mock/MockData.cs
+++ b/DotNet/Packer.Test/Mock/MockData.cs
@@ -14,7 +14,7 @@ public sealed class MockData : IDisposable
     public const string JSFileContent = "(function(){})();";
     public const string MapFileContent = "{version:3,file:\"dotnet.js\"}";
 
-    public string BaseDir { get; }
+    public string PublishDir { get; }
     public string BlazorOutDir { get; }
     public string JSDir { get; }
     public string WasmFile { get; }
@@ -31,8 +31,8 @@ public sealed class MockData : IDisposable
 
     public MockData ()
     {
-        BaseDir = Path.Combine(root, "base");
-        BlazorOutDir = Path.Combine(BaseDir, "blazor");
+        PublishDir = Path.Combine(root, "publish");
+        BlazorOutDir = Path.Combine(PublishDir, "blazor");
         JSDir = Path.Combine(root, "js");
         WasmFile = Path.Combine(JSDir, "dotnet.wasm");
         JSFile = Path.Combine(JSDir, "dotnet.js");
@@ -52,12 +52,12 @@ public sealed class MockData : IDisposable
 
     private string ReadGeneratedFileText (string fileName)
     {
-        var filePath = Path.Combine(BaseDir, fileName);
+        var filePath = Path.Combine(PublishDir, fileName);
         return File.Exists(filePath) ? File.ReadAllText(filePath) : null;
     }
 
     private PublishDotNetJS CreateTask () => new() {
-        BaseDir = BaseDir,
+        PublishDir = PublishDir,
         BlazorOutDir = BlazorOutDir,
         JSDir = JSDir,
         WasmFile = WasmFile,
@@ -67,7 +67,7 @@ public sealed class MockData : IDisposable
 
     private void CreateBuildResources ()
     {
-        Directory.CreateDirectory(BaseDir);
+        Directory.CreateDirectory(PublishDir);
         Directory.CreateDirectory(BlazorOutDir);
         Directory.CreateDirectory(JSDir);
         File.WriteAllText(WasmFile, WasmFileContent);

--- a/DotNet/Packer.Test/Packer.Test.csproj
+++ b/DotNet/Packer.Test/Packer.Test.csproj
@@ -6,9 +6,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.1"/>
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.2.0"/>
         <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.3.1"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1"/>
         <PackageReference Include="MSBuild.ProjectCreation" Version="8.2.1"/>
         <PackageReference Include="xunit" Version="2.4.2"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/DotNet/Packer.Test/Packer.Test.csproj
+++ b/DotNet/Packer.Test/Packer.Test.csproj
@@ -6,9 +6,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.2.0"/>
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.1"/>
         <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.3.1"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2"/>
         <PackageReference Include="MSBuild.ProjectCreation" Version="8.2.1"/>
         <PackageReference Include="xunit" Version="2.4.2"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/DotNet/Packer.Test/Packer.Test.csproj
+++ b/DotNet/Packer.Test/Packer.Test.csproj
@@ -8,7 +8,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.2.0"/>
         <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.3.1"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2"/>
         <PackageReference Include="MSBuild.ProjectCreation" Version="8.2.1"/>
         <PackageReference Include="xunit" Version="2.4.2"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/DotNet/Packer.Test/PublishTest.cs
+++ b/DotNet/Packer.Test/PublishTest.cs
@@ -42,18 +42,18 @@ public class PublishTest : BuildTest
     }
 
     [Fact]
-    public void BaseDirectoryCleanedByDefault ()
+    public void PublishDirectoryCleanedByDefault ()
     {
-        var filePath = Path.Combine(Data.BaseDir, "test");
+        var filePath = Path.Combine(Data.PublishDir, "test");
         File.WriteAllText(filePath, "");
         Task.Execute();
         Assert.False(File.Exists(filePath));
     }
 
     [Fact]
-    public void BaseDirectoryNotCleanedWhenRequested ()
+    public void PublishDirectoryNotCleanedWhenRequested ()
     {
-        var filePath = Path.Combine(Data.BaseDir, "test");
+        var filePath = Path.Combine(Data.PublishDir, "test");
         File.WriteAllText(filePath, "");
         Task.Clean = false;
         Task.Execute();

--- a/DotNet/Packer.Test/PublishTest.cs
+++ b/DotNet/Packer.Test/PublishTest.cs
@@ -42,6 +42,17 @@ public class PublishTest : BuildTest
     }
 
     [Fact]
+    public void AssembliesAndWasmArePublishedWhenEmbeddingDisabled ()
+    {
+        AddAssembly("Foo.dll");
+        Task.EmbedBinaries = false;
+        Task.Execute();
+        Assert.True(File.Exists(Path.Combine(Data.PublishDir, Data.WasmFile)));
+        Assert.True(File.Exists(Path.Combine(Data.PublishDir, "managed/Foo.dll")));
+        Assert.True(File.Exists(Path.Combine(Data.PublishDir, "managed/DotNetJS.dll")));
+    }
+
+    [Fact]
     public void PublishDirectoryCleanedByDefault ()
     {
         var filePath = Path.Combine(Data.PublishDir, "test");
@@ -70,7 +81,6 @@ public class PublishTest : BuildTest
         Assert.Contains(Engine.Messages, w => w.Contains("System.Runtime.dll"));
         Assert.Contains(Engine.Messages, w => w.Contains("Microsoft.JSInterop.dll"));
         Assert.Contains(Engine.Messages, w => w.Contains("System.Private.CoreLib.dll"));
-        Assert.Contains(Engine.Messages, w => w.Contains("System.Runtime.dll"));
     }
 
     [Fact]

--- a/DotNet/Packer/AssemblyInspector/Assembly.cs
+++ b/DotNet/Packer/AssemblyInspector/Assembly.cs
@@ -1,3 +1,3 @@
 ﻿namespace Packer;
 
-internal record Assembly(string Name, string Base64);
+internal record Assembly(string Name, byte[] Bytes);

--- a/DotNet/Packer/LibraryGenerator/EmbedTemplate.cs
+++ b/DotNet/Packer/LibraryGenerator/EmbedTemplate.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Packer;
@@ -22,6 +23,7 @@ internal class EmbedTemplate
 
     private static string EmbedAssembly (Assembly assembly)
     {
-        return $"{{ name: '{assembly.Name}', data: '{assembly.Base64}' }}";
+        var base64 = Convert.ToBase64String(assembly.Bytes);
+        return $"{{ name: '{assembly.Name}', data: '{base64}' }}";
     }
 }

--- a/DotNet/Packer/LibraryGenerator/LibraryGenerator.cs
+++ b/DotNet/Packer/LibraryGenerator/LibraryGenerator.cs
@@ -54,11 +54,11 @@ internal class LibraryGenerator
     {
         var assemblies = inspector.Assemblies.Select(a => $"\"{a.Name}\",");
         return JoinLines(1,
-            "exports.bootUris = {", JoinLines(2, true,
+            "exports.getBootUris = () => ({", JoinLines(2, true,
                 $"wasm: \"{wasmUri}\",",
                 $"entryAssembly: \"{entryAssemblyUri}\",",
                 "assemblies: [", JoinLines(assemblies, 3, true), "]"),
-            "};"
+            "});"
         );
     }
 

--- a/DotNet/Packer/LibraryGenerator/LibraryTemplate.cs
+++ b/DotNet/Packer/LibraryGenerator/LibraryTemplate.cs
@@ -4,15 +4,17 @@ internal class LibraryTemplate
 {
     public string RuntimeJS { get; init; } = null!;
     public string InitJS { get; init; } = null!;
+    public string? BootUris { get; init; }
+    public string? EmbedJS { get; init; }
 
-    public string Build (string? embedJS = null) => $@"{RuntimeJS}
+    public string Build () => $@"{RuntimeJS}
 (function (root, factory) {{
     if (typeof exports === 'object' && typeof exports.nodeName !== 'string')
         factory(module.exports, global);
     else factory(root.dotnet, root);
 }}(typeof self !== 'undefined' ? self : this, function (exports, global) {{
     {InitJS}
-    {embedJS ?? ""}
+    {EmbedJS ?? BootUris}
     global.dotnet = exports;
 }}));";
 }

--- a/DotNet/Packer/PublishDotNetJS.cs
+++ b/DotNet/Packer/PublishDotNetJS.cs
@@ -7,7 +7,7 @@ namespace Packer;
 
 public class PublishDotNetJS : Task
 {
-    [Required] public string BaseDir { get; set; } = null!;
+    [Required] public string PublishDir { get; set; } = null!;
     [Required] public string BlazorOutDir { get; set; } = null!;
     [Required] public string JSDir { get; set; } = null!;
     [Required] public string WasmFile { get; set; } = null!;
@@ -18,7 +18,7 @@ public class PublishDotNetJS : Task
     public override bool Execute ()
     {
         var (library, declaration) = GenerateSources();
-        if (Clean) CleanBaseDirectory();
+        if (Clean) CleanPublishDirectory();
         PublishLibrary(library);
         PublishDeclaration(declaration);
         PublishSourceMap();
@@ -32,29 +32,29 @@ public class PublishDotNetJS : Task
         return (GenerateLibrary(inspector, builder), GenerateDeclaration(inspector, builder));
     }
 
-    private void CleanBaseDirectory ()
+    private void CleanPublishDirectory ()
     {
-        Directory.Delete(BaseDir, true);
-        Directory.CreateDirectory(BaseDir);
+        Directory.Delete(PublishDir, true);
+        Directory.CreateDirectory(PublishDir);
     }
 
     private void PublishLibrary (string source)
     {
-        var path = Path.Combine(BaseDir, "dotnet.js");
+        var path = Path.Combine(PublishDir, "dotnet.js");
         File.WriteAllText(path, source);
         Log.LogMessage(MessageImportance.High, $"JavaScript UMD library is published at {path}.");
     }
 
     private void PublishDeclaration (string source)
     {
-        var file = Path.Combine(BaseDir, "dotnet.d.ts");
+        var file = Path.Combine(PublishDir, "dotnet.d.ts");
         File.WriteAllText(file, source);
     }
 
     private void PublishSourceMap ()
     {
         var source = Path.Combine(JSDir, "dotnet.js.map");
-        var destination = Path.Combine(BaseDir, "dotnet.js.map");
+        var destination = Path.Combine(PublishDir, "dotnet.js.map");
         File.Copy(source, destination, true);
     }
 

--- a/DotNet/Packer/Utilities/TextUtilities.cs
+++ b/DotNet/Packer/Utilities/TextUtilities.cs
@@ -8,21 +8,21 @@ internal static class TextUtilities
 {
     public static IEnumerable<string> SplitLines (string input)
     {
-        var line = default(string);
         using var reader = new StringReader(input);
-        while ((line = reader.ReadLine()) != null)
+        while (reader.ReadLine() is { } line)
             yield return line;
     }
 
-    public static string JoinLines (IEnumerable<string> values, int indent = 1)
+    public static string JoinLines (IEnumerable<string> values, int indent = 1, bool indentFirst = false)
     {
         var separator = "\n" + new string(' ', indent * 4);
-        return RemoveEmptyLines(string.Join(separator, values));
+        var result = RemoveEmptyLines(string.Join(separator, values));
+        return indentFirst ? separator + result : result;
     }
 
     public static string JoinLines (params string[] values) => JoinLines(values, 1);
-
     public static string JoinLines (int indent, params string[] values) => JoinLines(values, indent);
+    public static string JoinLines (int indent, bool indentFirst, params string[] values) => JoinLines(values, indent, indentFirst);
 
     public static string ToFirstLower (string value)
     {

--- a/JavaScript/package-lock.json
+++ b/JavaScript/package-lock.json
@@ -10,11 +10,11 @@
                 "js-base64": "^3.7.2",
                 "mocha": "^10.0.0",
                 "nyc": "^15.1.0",
-                "ts-loader": "^9.3.0",
-                "typescript": "^4.7.3",
-                "webpack": "^5.73.0",
-                "webpack-cli": "^4.9.2",
-                "ws": "^8.7.0"
+                "ts-loader": "^9.4.1",
+                "typescript": "^4.8.4",
+                "webpack": "^5.74.0",
+                "webpack-cli": "^4.10.0",
+                "ws": "^8.9.0"
             }
         },
         "node_modules/@ampproject/remapping": {
@@ -769,9 +769,9 @@
             }
         },
         "node_modules/@webpack-cli/configtest": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.1.1.tgz",
-            "integrity": "sha512-1FBc1f9G4P/AxMqIgfZgeOTuRnwZMten8E7zap5zgpPInnCrP8D4Q81+4CWIch8i/Nf7nXjP0v6CjjbHOrXhKg==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.2.0.tgz",
+            "integrity": "sha512-4FB8Tj6xyVkyqjj1OaTqCjXYULB9FMkqQ8yGrZjRDrYh0nOE+7Lhs45WioWQQMV+ceFlE368Ukhe6xdvJM9Egg==",
             "dev": true,
             "peerDependencies": {
                 "webpack": "4.x.x || 5.x.x",
@@ -779,9 +779,9 @@
             }
         },
         "node_modules/@webpack-cli/info": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.4.1.tgz",
-            "integrity": "sha512-PKVGmazEq3oAo46Q63tpMr4HipI3OPfP7LiNOEJg963RMgT0rqheag28NCML0o3GIzA3DmxP1ZIAv9oTX1CUIA==",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.5.0.tgz",
+            "integrity": "sha512-e8tSXZpw2hPl2uMJY6fsMswaok5FdlGNRTktvFk2sD8RjH0hE2+XistawJx1vmKteh4NmGmNUrp+Tb2w+udPcQ==",
             "dev": true,
             "dependencies": {
                 "envinfo": "^7.7.3"
@@ -791,9 +791,9 @@
             }
         },
         "node_modules/@webpack-cli/serve": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.6.1.tgz",
-            "integrity": "sha512-gNGTiTrjEVQ0OcVnzsRSqTxaBSr+dmTfm+qJsCDluky8uhdLWep7Gcr62QsAKHTMxjCS/8nEITsmFAhfIx+QSw==",
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.7.0.tgz",
+            "integrity": "sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==",
             "dev": true,
             "peerDependencies": {
                 "webpack-cli": "4.x.x"
@@ -1291,9 +1291,9 @@
             "dev": true
         },
         "node_modules/enhanced-resolve": {
-            "version": "5.9.3",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.9.3.tgz",
-            "integrity": "sha512-Bq9VSor+kjvW3f9/MiiR4eE3XYgOl7/rS8lnSxbRbF3kS0B2r+Y9w5krBWxZgDxASVZbdYrn5wT4j/Wb0J9qow==",
+            "version": "5.10.0",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.10.0.tgz",
+            "integrity": "sha512-T0yTFjdpldGY8PmuXXR0PyQ1ufZpEGiHVrp7zHKB7jdR4qlmZHhONVM5AQOAWXuF/w3dnHbEQVrNptJgt7F+cQ==",
             "dev": true,
             "dependencies": {
                 "graceful-fs": "^4.2.4",
@@ -1411,29 +1411,6 @@
             "dev": true,
             "engines": {
                 "node": ">=0.8.x"
-            }
-        },
-        "node_modules/execa": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
-            "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
-            "dev": true,
-            "dependencies": {
-                "cross-spawn": "^7.0.3",
-                "get-stream": "^6.0.0",
-                "human-signals": "^2.1.0",
-                "is-stream": "^2.0.0",
-                "merge-stream": "^2.0.0",
-                "npm-run-path": "^4.0.1",
-                "onetime": "^5.1.2",
-                "signal-exit": "^3.0.3",
-                "strip-final-newline": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/execa?sponsor=1"
             }
         },
         "node_modules/fast-deep-equal": {
@@ -1594,18 +1571,6 @@
                 "node": ">=8.0.0"
             }
         },
-        "node_modules/get-stream": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-            "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/glob": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
@@ -1732,15 +1697,6 @@
             "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
             "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
             "dev": true
-        },
-        "node_modules/human-signals": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
-            "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
-            "dev": true,
-            "engines": {
-                "node": ">=10.17.0"
-            }
         },
         "node_modules/import-local": {
             "version": "3.1.0",
@@ -2244,15 +2200,6 @@
                 "node": ">= 0.6"
             }
         },
-        "node_modules/mimic-fn": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-            "dev": true,
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/minimatch": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
@@ -2355,18 +2302,6 @@
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/npm-run-path": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-            "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-            "dev": true,
-            "dependencies": {
-                "path-key": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/nyc": {
@@ -2535,21 +2470,6 @@
             "dev": true,
             "dependencies": {
                 "wrappy": "1"
-            }
-        },
-        "node_modules/onetime": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-            "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-            "dev": true,
-            "dependencies": {
-                "mimic-fn": "^2.1.0"
-            },
-            "engines": {
-                "node": ">=6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/p-limit": {
@@ -3031,15 +2951,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/strip-final-newline": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-            "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
-            "dev": true,
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/strip-json-comments": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -3198,9 +3109,9 @@
             }
         },
         "node_modules/ts-loader": {
-            "version": "9.3.0",
-            "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.3.0.tgz",
-            "integrity": "sha512-2kLLAdAD+FCKijvGKi9sS0OzoqxLCF3CxHpok7rVgCZ5UldRzH0TkbwG9XECKjBzHsAewntC5oDaI/FwKzEUog==",
+            "version": "9.4.1",
+            "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.4.1.tgz",
+            "integrity": "sha512-384TYAqGs70rn9F0VBnh6BPTfhga7yFNdC5gXbQpDrBj9/KsT4iRkGqKXhziofHOlE2j6YEaiTYVGKKvPhGWvw==",
             "dev": true,
             "dependencies": {
                 "chalk": "^4.1.0",
@@ -3250,9 +3161,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "4.7.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.3.tgz",
-            "integrity": "sha512-WOkT3XYvrpXx4vMMqlD+8R8R37fZkjyLGlxavMc4iB8lrl8L0DeTcHbYgw/v0N/z9wAFsgBhcsF0ruoySS22mA==",
+            "version": "4.8.4",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+            "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
@@ -3294,9 +3205,9 @@
             }
         },
         "node_modules/webpack": {
-            "version": "5.73.0",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.73.0.tgz",
-            "integrity": "sha512-svjudQRPPa0YiOYa2lM/Gacw0r6PvxptHj4FuEKQ2kX05ZLkjbVc5MnPs6its5j7IZljnIqSVo/OsY2X0IpHGA==",
+            "version": "5.74.0",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.74.0.tgz",
+            "integrity": "sha512-A2InDwnhhGN4LYctJj6M1JEaGL7Luj6LOmyBHjcI8529cm5p6VXiTIW2sn6ffvEAKmveLzvu4jrihwXtPojlAA==",
             "dev": true,
             "dependencies": {
                 "@types/eslint-scope": "^3.7.3",
@@ -3304,11 +3215,11 @@
                 "@webassemblyjs/ast": "1.11.1",
                 "@webassemblyjs/wasm-edit": "1.11.1",
                 "@webassemblyjs/wasm-parser": "1.11.1",
-                "acorn": "^8.4.1",
+                "acorn": "^8.7.1",
                 "acorn-import-assertions": "^1.7.6",
                 "browserslist": "^4.14.5",
                 "chrome-trace-event": "^1.0.2",
-                "enhanced-resolve": "^5.9.3",
+                "enhanced-resolve": "^5.10.0",
                 "es-module-lexer": "^0.9.0",
                 "eslint-scope": "5.1.1",
                 "events": "^3.2.0",
@@ -3321,7 +3232,7 @@
                 "schema-utils": "^3.1.0",
                 "tapable": "^2.1.1",
                 "terser-webpack-plugin": "^5.1.3",
-                "watchpack": "^2.3.1",
+                "watchpack": "^2.4.0",
                 "webpack-sources": "^3.2.3"
             },
             "bin": {
@@ -3341,18 +3252,18 @@
             }
         },
         "node_modules/webpack-cli": {
-            "version": "4.9.2",
-            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.9.2.tgz",
-            "integrity": "sha512-m3/AACnBBzK/kMTcxWHcZFPrw/eQuY4Df1TxvIWfWM2x7mRqBQCqKEd96oCUa9jkapLBaFfRce33eGDb4Pr7YQ==",
+            "version": "4.10.0",
+            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.10.0.tgz",
+            "integrity": "sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==",
             "dev": true,
             "dependencies": {
                 "@discoveryjs/json-ext": "^0.5.0",
-                "@webpack-cli/configtest": "^1.1.1",
-                "@webpack-cli/info": "^1.4.1",
-                "@webpack-cli/serve": "^1.6.1",
+                "@webpack-cli/configtest": "^1.2.0",
+                "@webpack-cli/info": "^1.5.0",
+                "@webpack-cli/serve": "^1.7.0",
                 "colorette": "^2.0.14",
                 "commander": "^7.0.0",
-                "execa": "^5.0.0",
+                "cross-spawn": "^7.0.3",
                 "fastest-levenshtein": "^1.0.12",
                 "import-local": "^3.0.2",
                 "interpret": "^2.2.0",
@@ -3364,6 +3275,10 @@
             },
             "engines": {
                 "node": ">=10.13.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
             },
             "peerDependencies": {
                 "webpack": "4.x.x || 5.x.x"
@@ -3483,9 +3398,9 @@
             }
         },
         "node_modules/ws": {
-            "version": "8.7.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.7.0.tgz",
-            "integrity": "sha512-c2gsP0PRwcLFzUiA8Mkr37/MI7ilIlHQxaEAtd0uNMbVMoy8puJyafRlm0bV9MbGSabUPeLrRRaqIBcFcA2Pqg==",
+            "version": "8.9.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.9.0.tgz",
+            "integrity": "sha512-Ja7nszREasGaYUYCI2k4lCKIRTt+y7XuqVoHR44YpI49TtryyqbqvDMn5eqfW7e6HzTukDRIsXqzVHScqRcafg==",
             "dev": true,
             "engines": {
                 "node": ">=10.0.0"
@@ -4228,25 +4143,25 @@
             }
         },
         "@webpack-cli/configtest": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.1.1.tgz",
-            "integrity": "sha512-1FBc1f9G4P/AxMqIgfZgeOTuRnwZMten8E7zap5zgpPInnCrP8D4Q81+4CWIch8i/Nf7nXjP0v6CjjbHOrXhKg==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.2.0.tgz",
+            "integrity": "sha512-4FB8Tj6xyVkyqjj1OaTqCjXYULB9FMkqQ8yGrZjRDrYh0nOE+7Lhs45WioWQQMV+ceFlE368Ukhe6xdvJM9Egg==",
             "dev": true,
             "requires": {}
         },
         "@webpack-cli/info": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.4.1.tgz",
-            "integrity": "sha512-PKVGmazEq3oAo46Q63tpMr4HipI3OPfP7LiNOEJg963RMgT0rqheag28NCML0o3GIzA3DmxP1ZIAv9oTX1CUIA==",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.5.0.tgz",
+            "integrity": "sha512-e8tSXZpw2hPl2uMJY6fsMswaok5FdlGNRTktvFk2sD8RjH0hE2+XistawJx1vmKteh4NmGmNUrp+Tb2w+udPcQ==",
             "dev": true,
             "requires": {
                 "envinfo": "^7.7.3"
             }
         },
         "@webpack-cli/serve": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.6.1.tgz",
-            "integrity": "sha512-gNGTiTrjEVQ0OcVnzsRSqTxaBSr+dmTfm+qJsCDluky8uhdLWep7Gcr62QsAKHTMxjCS/8nEITsmFAhfIx+QSw==",
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.7.0.tgz",
+            "integrity": "sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==",
             "dev": true,
             "requires": {}
         },
@@ -4616,9 +4531,9 @@
             "dev": true
         },
         "enhanced-resolve": {
-            "version": "5.9.3",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.9.3.tgz",
-            "integrity": "sha512-Bq9VSor+kjvW3f9/MiiR4eE3XYgOl7/rS8lnSxbRbF3kS0B2r+Y9w5krBWxZgDxASVZbdYrn5wT4j/Wb0J9qow==",
+            "version": "5.10.0",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.10.0.tgz",
+            "integrity": "sha512-T0yTFjdpldGY8PmuXXR0PyQ1ufZpEGiHVrp7zHKB7jdR4qlmZHhONVM5AQOAWXuF/w3dnHbEQVrNptJgt7F+cQ==",
             "dev": true,
             "requires": {
                 "graceful-fs": "^4.2.4",
@@ -4699,23 +4614,6 @@
             "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
             "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
             "dev": true
-        },
-        "execa": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
-            "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
-            "dev": true,
-            "requires": {
-                "cross-spawn": "^7.0.3",
-                "get-stream": "^6.0.0",
-                "human-signals": "^2.1.0",
-                "is-stream": "^2.0.0",
-                "merge-stream": "^2.0.0",
-                "npm-run-path": "^4.0.1",
-                "onetime": "^5.1.2",
-                "signal-exit": "^3.0.3",
-                "strip-final-newline": "^2.0.0"
-            }
         },
         "fast-deep-equal": {
             "version": "3.1.3",
@@ -4824,12 +4722,6 @@
             "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
             "dev": true
         },
-        "get-stream": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-            "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-            "dev": true
-        },
         "glob": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
@@ -4927,12 +4819,6 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
             "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
-            "dev": true
-        },
-        "human-signals": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
-            "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
             "dev": true
         },
         "import-local": {
@@ -5301,12 +5187,6 @@
                 "mime-db": "1.52.0"
             }
         },
-        "mimic-fn": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-            "dev": true
-        },
         "minimatch": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
@@ -5384,15 +5264,6 @@
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
             "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
             "dev": true
-        },
-        "npm-run-path": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-            "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-            "dev": true,
-            "requires": {
-                "path-key": "^3.0.0"
-            }
         },
         "nyc": {
             "version": "15.1.0",
@@ -5532,15 +5403,6 @@
             "dev": true,
             "requires": {
                 "wrappy": "1"
-            }
-        },
-        "onetime": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-            "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-            "dev": true,
-            "requires": {
-                "mimic-fn": "^2.1.0"
             }
         },
         "p-limit": {
@@ -5900,12 +5762,6 @@
             "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
             "dev": true
         },
-        "strip-final-newline": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-            "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
-            "dev": true
-        },
         "strip-json-comments": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -6006,9 +5862,9 @@
             }
         },
         "ts-loader": {
-            "version": "9.3.0",
-            "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.3.0.tgz",
-            "integrity": "sha512-2kLLAdAD+FCKijvGKi9sS0OzoqxLCF3CxHpok7rVgCZ5UldRzH0TkbwG9XECKjBzHsAewntC5oDaI/FwKzEUog==",
+            "version": "9.4.1",
+            "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.4.1.tgz",
+            "integrity": "sha512-384TYAqGs70rn9F0VBnh6BPTfhga7yFNdC5gXbQpDrBj9/KsT4iRkGqKXhziofHOlE2j6YEaiTYVGKKvPhGWvw==",
             "dev": true,
             "requires": {
                 "chalk": "^4.1.0",
@@ -6044,9 +5900,9 @@
             }
         },
         "typescript": {
-            "version": "4.7.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.3.tgz",
-            "integrity": "sha512-WOkT3XYvrpXx4vMMqlD+8R8R37fZkjyLGlxavMc4iB8lrl8L0DeTcHbYgw/v0N/z9wAFsgBhcsF0ruoySS22mA==",
+            "version": "4.8.4",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+            "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
             "dev": true
         },
         "uri-js": {
@@ -6075,9 +5931,9 @@
             }
         },
         "webpack": {
-            "version": "5.73.0",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.73.0.tgz",
-            "integrity": "sha512-svjudQRPPa0YiOYa2lM/Gacw0r6PvxptHj4FuEKQ2kX05ZLkjbVc5MnPs6its5j7IZljnIqSVo/OsY2X0IpHGA==",
+            "version": "5.74.0",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.74.0.tgz",
+            "integrity": "sha512-A2InDwnhhGN4LYctJj6M1JEaGL7Luj6LOmyBHjcI8529cm5p6VXiTIW2sn6ffvEAKmveLzvu4jrihwXtPojlAA==",
             "dev": true,
             "requires": {
                 "@types/eslint-scope": "^3.7.3",
@@ -6085,11 +5941,11 @@
                 "@webassemblyjs/ast": "1.11.1",
                 "@webassemblyjs/wasm-edit": "1.11.1",
                 "@webassemblyjs/wasm-parser": "1.11.1",
-                "acorn": "^8.4.1",
+                "acorn": "^8.7.1",
                 "acorn-import-assertions": "^1.7.6",
                 "browserslist": "^4.14.5",
                 "chrome-trace-event": "^1.0.2",
-                "enhanced-resolve": "^5.9.3",
+                "enhanced-resolve": "^5.10.0",
                 "es-module-lexer": "^0.9.0",
                 "eslint-scope": "5.1.1",
                 "events": "^3.2.0",
@@ -6102,23 +5958,23 @@
                 "schema-utils": "^3.1.0",
                 "tapable": "^2.1.1",
                 "terser-webpack-plugin": "^5.1.3",
-                "watchpack": "^2.3.1",
+                "watchpack": "^2.4.0",
                 "webpack-sources": "^3.2.3"
             }
         },
         "webpack-cli": {
-            "version": "4.9.2",
-            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.9.2.tgz",
-            "integrity": "sha512-m3/AACnBBzK/kMTcxWHcZFPrw/eQuY4Df1TxvIWfWM2x7mRqBQCqKEd96oCUa9jkapLBaFfRce33eGDb4Pr7YQ==",
+            "version": "4.10.0",
+            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.10.0.tgz",
+            "integrity": "sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==",
             "dev": true,
             "requires": {
                 "@discoveryjs/json-ext": "^0.5.0",
-                "@webpack-cli/configtest": "^1.1.1",
-                "@webpack-cli/info": "^1.4.1",
-                "@webpack-cli/serve": "^1.6.1",
+                "@webpack-cli/configtest": "^1.2.0",
+                "@webpack-cli/info": "^1.5.0",
+                "@webpack-cli/serve": "^1.7.0",
                 "colorette": "^2.0.14",
                 "commander": "^7.0.0",
-                "execa": "^5.0.0",
+                "cross-spawn": "^7.0.3",
                 "fastest-levenshtein": "^1.0.12",
                 "import-local": "^3.0.2",
                 "interpret": "^2.2.0",
@@ -6207,9 +6063,9 @@
             }
         },
         "ws": {
-            "version": "8.7.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.7.0.tgz",
-            "integrity": "sha512-c2gsP0PRwcLFzUiA8Mkr37/MI7ilIlHQxaEAtd0uNMbVMoy8puJyafRlm0bV9MbGSabUPeLrRRaqIBcFcA2Pqg==",
+            "version": "8.9.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.9.0.tgz",
+            "integrity": "sha512-Ja7nszREasGaYUYCI2k4lCKIRTt+y7XuqVoHR44YpI49TtryyqbqvDMn5eqfW7e6HzTukDRIsXqzVHScqRcafg==",
             "dev": true,
             "requires": {}
         },

--- a/JavaScript/package.json
+++ b/JavaScript/package.json
@@ -8,14 +8,14 @@
         "bench": "mocha test/bench.js --timeout 0"
     },
     "devDependencies": {
-        "typescript": "^4.7.3",
+        "typescript": "^4.8.4",
         "@types/emscripten": "^1.39.6",
         "js-base64": "^3.7.2",
-        "webpack": "^5.73.0",
-        "webpack-cli": "^4.9.2",
-        "ts-loader": "^9.3.0",
+        "webpack": "^5.74.0",
+        "webpack-cli": "^4.10.0",
+        "ts-loader": "^9.4.1",
         "mocha": "^10.0.0",
         "nyc": "^15.1.0",
-        "ws": "^8.7.0"
+        "ws": "^8.9.0"
     }
 }

--- a/JavaScript/src/boot.ts
+++ b/JavaScript/src/boot.ts
@@ -3,6 +3,12 @@ import { initializeInterop } from "./interop";
 import { Assembly, initializeMono, callEntryPoint } from "./mono";
 import { Base64 } from "js-base64";
 
+export interface BootUris {
+    wasm: string;
+    assemblies: string[];
+    entryAssembly: string;
+}
+
 export interface BootData {
     wasm: Uint8Array | string;
     assemblies: Assembly[];
@@ -17,6 +23,10 @@ export enum BootStatus {
 }
 
 let bootStatus: BootStatus = BootStatus.Standby;
+
+export function getBootUris(): BootUris | undefined {
+    return undefined;
+}
 
 export function getBootStatus(): BootStatus {
     return bootStatus;

--- a/JavaScript/src/dotnet.ts
+++ b/JavaScript/src/dotnet.ts
@@ -1,20 +1,14 @@
-﻿import { boot, getBootStatus, terminate, BootStatus, BootData } from "./boot";
+﻿import { boot, getBootUris, getBootStatus, terminate, BootStatus, BootData, BootUris } from "./boot";
 import { invoke, invokeAsync, createObjectReference, disposeObjectReference, createStreamReference } from "./interop";
 import { Assembly } from "./mono";
 import { Event } from "./event";
 
-export type BootUris = {
-    wasm: string;
-    entryAssembly: string;
-    assemblies: string[]
-}
-
 export const dotnet = {
     Event: Event,
     BootStatus: BootStatus,
+    getBootUris: getBootUris,
     getBootStatus: getBootStatus,
     boot: boot,
-    bootUris: undefined as BootUris | undefined,
     terminate: terminate,
     invoke: invoke,
     invokeAsync: invokeAsync,
@@ -25,6 +19,7 @@ export const dotnet = {
 
 export {
     BootStatus,
+    BootUris,
     BootData,
     Assembly
 };

--- a/JavaScript/src/dotnet.ts
+++ b/JavaScript/src/dotnet.ts
@@ -3,11 +3,18 @@ import { invoke, invokeAsync, createObjectReference, disposeObjectReference, cre
 import { Assembly } from "./mono";
 import { Event } from "./event";
 
+export type BootUris = {
+    wasm: string;
+    entryAssembly: string;
+    assemblies: string[]
+}
+
 export const dotnet = {
     Event: Event,
     BootStatus: BootStatus,
     getBootStatus: getBootStatus,
     boot: boot,
+    bootUris: undefined as BootUris | undefined,
     terminate: terminate,
     invoke: invoke,
     invokeAsync: invokeAsync,

--- a/JavaScript/test/boot.js
+++ b/JavaScript/test/boot.js
@@ -1,5 +1,5 @@
 ﻿const assert = require("assert");
-const { boot, terminate, getBootStatus, BootStatus, invoke } = require("../dist/dotnet");
+const { boot, terminate, getBootUris, getBootStatus, BootStatus, invoke } = require("../dist/dotnet");
 const { bootTest, getBootData } = require("./csharp");
 const { Base64 } = require("js-base64");
 
@@ -61,5 +61,8 @@ describe("boot", () => {
         await boot(data);
         assert.deepStrictEqual(getBootStatus(), BootStatus.Booted);
         terminate();
+    });
+    it("get uris return undefined when embed binaries is enabled", () => {
+        assert.strictEqual(getBootUris(), undefined);
     });
 });

--- a/JavaScript/test/csharp/Test.Main/Test.Main.csproj
+++ b/JavaScript/test/csharp/Test.Main/Test.Main.csproj
@@ -3,7 +3,6 @@
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
         <Clean>false</Clean>
-        <EmitSourceMap>true</EmitSourceMap>
         <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
         <CompilerGeneratedFilesOutputPath>bin/codegen</CompilerGeneratedFilesOutputPath>
         <DotNetRoot>../../../../DotNet</DotNetRoot>

--- a/README.md
+++ b/README.md
@@ -156,8 +156,8 @@ The `dotnet.wasm` and solution's assemblies will be emitted in the build output 
 
 ```js
 const bootData = {
-    wasm: <Uint8Array>,
-    assemblies: [ { name: "Foo.dll", data: <Uint8Array> } ],
+    wasm: Uint8Array,
+    assemblies: [ { name: "Foo.dll", data: Uint8Array } ],
     entryAssemblyName: "Foo.dll"
 };
 await dotnet.boot(bootData);


### PR DESCRIPTION
This makes using the library with binaries sideloading more comfortable:

 - When `EmbedBinaries` is disabled the wasm and DLLs will be published with the build output
 - Added `getBootUris()` function returning entry assembly name and identifiers of all the binaries required for boot

Boot data can now be fetched as follows:

```js
async function fetchBootData() {
    const uris = getBootUris();
    return {
        wasm: await fetchBinary(uris.wasm),
        assemblies: await Promise.all(uris.assemblies.map(fetchAssembly)),
        entryAssemblyName: uris.entryAssembly
    };

    async function fetchBinary(name: string) {
        // assuming all the binaries are hosted under /bin
        const uri = `${process.env.PUBLIC_URL}/bin/${name}`;
        return new Uint8Array(await (await fetch(uri)).arrayBuffer());
    }

    async function fetchAssembly(name: string) {
        return { name, data: await fetchBinary(name) };
    }
}
```