### PR TITLE
chore(ci): fix codecov paths with new uploader

### DIFF
--- a/.github/workflows/cover.yml
+++ b/.github/workflows/cover.yml
@@ -22,8 +22,7 @@ jobs:
           npm ci
           npm run build
           dotnet publish test/csharp/Test.sln
-          npm install -g codecov
           npm install -g nyc
           nyc --reporter=lcov -x **/native -x **/bin -x **/dotnet-js-interop.ts npm run test
-          cd ../..
-          codecov
+      - name: upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3


### PR DESCRIPTION
re: [Codecov community post](https://community.codecov.com/t/unable-to-show-line-by-line-coverage/3982)

@Elringus looks like this might just be an issue with the deprecated uploader. I made this fix on my fork, and you can see the file contents [here](https://app.codecov.io/github/thomasrockhu-codecov/DotNetJS/blob/main/DotNet/Generator/Common.cs). 