### PR TITLE
Add TypeScript declarations for C# structs

### DIFF
--- a/DotNet/Packer.Test/DeclarationTest.cs
+++ b/DotNet/Packer.Test/DeclarationTest.cs
@@ -437,6 +437,23 @@ public class DeclarationTest : ContentTest
     }
 
     [Fact]
+    public void CanCrawlStructTypes ()
+    {
+        AddAssembly(
+            With("n","public struct StructType { public double A { get; set; } }"),
+            With("n","public readonly struct ReadonlyStructType { public double A { get; init; } }"),
+            With("n","public readonly record struct ReadonlyRecordStructType { public double A { get; init; } }"),
+            With("n","[JSInvokable] public static StructType GetStruct () => default;"),
+            With("n","[JSInvokable] public static ReadonlyStructType GetReadonlyStruct () => default;"),
+            With("n", "[JSInvokable] public static ReadonlyRecordStructType GetReadonlyStructRecord () => default;")
+        );
+        Task.Execute();
+        Matches(@"export class StructType {\s*a: number;\s*}");
+        Matches(@"export class ReadonlyStructType {\s*a: number;\s*}");
+        Matches(@"export class ReadonlyRecordStructType {\s*a: number;\s*}");
+    }
+
+    [Fact]
     public void OtherTypesAreTranslatedToAny ()
     {
         AddAssembly(With("[JSInvokable] public static DBNull Method (DBNull t) => default;"));

--- a/DotNet/Packer.Test/DeclarationTest.cs
+++ b/DotNet/Packer.Test/DeclarationTest.cs
@@ -423,34 +423,24 @@ public class DeclarationTest : ContentTest
     public void CanCrawlCustomTypes ()
     {
         AddAssembly(
-            With("n", "public enum Nyam { A, B }"),
-            With("n", "public class Foo { public Nyam Nyam { get; } }"),
-            With("n", "public record Baz(string Name);"),
-            With("n", "public class Bar : Foo { public Baz baz { get; } }"),
-            With("n", "public class Barrel { public List<Bar> Bars { get; } }"),
-            With("n", "[JSInvokable] public static Barrel GetBarrel () => default;"));
+            With("n", "public struct Struct { public double A { get; set; } }"),
+            With("n", "public readonly struct ReadonlyStruct { public double A { get; init; } }"),
+            With("n", "public readonly record struct ReadonlyRecordStruct(double A);"),
+            With("n", "public record class RecordClass(double A);"),
+            With("n", "public enum Enum { A, B }"),
+            With("n", "public class Foo { public Struct S { get; } public ReadonlyStruct Rs { get; } }"),
+            With("n", "public class Bar : Foo { public ReadonlyRecordStruct Rrs { get; } public RecordClass Rc { get; } }"),
+            With("n", "public class Baz { public List<Bar> Bars { get; } public Enum E { get; } }"),
+            With("n", "[JSInvokable] public static Baz GetBaz () => default;"));
         Task.Execute();
-        Matches(@"export enum Nyam {\s*A,\s*B\s*}");
-        Matches(@"export class Foo {\s*nyam: n.Nyam;\s*}");
-        Matches(@"export class Bar extends n.Foo {\s*baz: n.Baz;\s*}");
-        Matches(@"export class Baz {\s*name: string;\s*}");
-    }
-
-    [Fact]
-    public void CanCrawlStructTypes ()
-    {
-        AddAssembly(
-            With("n","public struct StructType { public double A { get; set; } }"),
-            With("n","public readonly struct ReadonlyStructType { public double A { get; init; } }"),
-            With("n","public readonly record struct ReadonlyRecordStructType { public double A { get; init; } }"),
-            With("n","[JSInvokable] public static StructType GetStruct () => default;"),
-            With("n","[JSInvokable] public static ReadonlyStructType GetReadonlyStruct () => default;"),
-            With("n", "[JSInvokable] public static ReadonlyRecordStructType GetReadonlyStructRecord () => default;")
-        );
-        Task.Execute();
-        Matches(@"export class StructType {\s*a: number;\s*}");
-        Matches(@"export class ReadonlyStructType {\s*a: number;\s*}");
-        Matches(@"export class ReadonlyRecordStructType {\s*a: number;\s*}");
+        Matches(@"export class Struct {\s*a: number;\s*}");
+        Matches(@"export class ReadonlyStruct {\s*a: number;\s*}");
+        Matches(@"export class ReadonlyRecordStruct {\s*a: number;\s*}");
+        Matches(@"export class RecordClass {\s*a: number;\s*}");
+        Matches(@"export enum Enum {\s*A,\s*B\s*}");
+        Matches(@"export class Foo {\s*s: n.Struct;\s*rs: n.ReadonlyStruct;\s*}");
+        Matches(@"export class Bar extends n.Foo {\s*rrs: n.ReadonlyRecordStruct;\s*rc: n.RecordClass;\s*}");
+        Matches(@"export class Baz {\s*bars: Array<n.Bar>;\s*e: n.Enum;\s*}");
     }
 
     [Fact]

--- a/DotNet/Packer.Test/DeclarationTest.cs
+++ b/DotNet/Packer.Test/DeclarationTest.cs
@@ -425,13 +425,15 @@ public class DeclarationTest : ContentTest
         AddAssembly(
             With("n", "public enum Nyam { A, B }"),
             With("n", "public class Foo { public Nyam Nyam { get; } }"),
-            With("n", "public class Bar : Foo { }"),
+            With("n", "public record Baz(string Name);"),
+            With("n", "public class Bar : Foo { public Baz baz { get; } }"),
             With("n", "public class Barrel { public List<Bar> Bars { get; } }"),
             With("n", "[JSInvokable] public static Barrel GetBarrel () => default;"));
         Task.Execute();
         Matches(@"export enum Nyam {\s*A,\s*B\s*}");
         Matches(@"export class Foo {\s*nyam: n.Nyam;\s*}");
-        Matches(@"export class Bar extends n.Foo {\s*}");
+        Matches(@"export class Bar extends n.Foo {\s*baz: n.Baz;\s*}");
+        Matches(@"export class Baz {\s*name: string;\s*}");
     }
 
     [Fact]

--- a/DotNet/Packer/DeclarationGenerator/TypeDeclarationGenerator.cs
+++ b/DotNet/Packer/DeclarationGenerator/TypeDeclarationGenerator.cs
@@ -44,7 +44,7 @@ internal class TypeDeclarationGenerator
     private void DeclareType ()
     {
         if (ShouldOpenNamespace()) OpenNamespace();
-        if (type.IsClass) DeclareClass();
+        if (type.IsClass || IsStructType()) DeclareClass();
         if (type.IsInterface) DeclareInterface();
         if (type.IsEnum) DeclareEnum();
         if (ShouldCloseNamespace()) CloseNamespace();
@@ -102,6 +102,8 @@ internal class TypeDeclarationGenerator
             else AppendLine($"{names[i]},", 2);
         AppendLine("}", 1);
     }
+
+    private bool IsStructType () => type is { IsClass: false, IsEnum: false, IsValueType: true, IsPrimitive: false };
 
     private string GetNamespace (Type type)
     {

--- a/DotNet/Packer/DeclarationGenerator/TypeDeclarationGenerator.cs
+++ b/DotNet/Packer/DeclarationGenerator/TypeDeclarationGenerator.cs
@@ -44,9 +44,9 @@ internal class TypeDeclarationGenerator
     private void DeclareType ()
     {
         if (ShouldOpenNamespace()) OpenNamespace();
-        if (type.IsClass || IsStructType()) DeclareClass();
-        if (type.IsInterface) DeclareInterface();
         if (type.IsEnum) DeclareEnum();
+        else if (type.IsInterface) DeclareInterface();
+        else DeclareClass();
         if (ShouldCloseNamespace()) CloseNamespace();
     }
 
@@ -102,8 +102,6 @@ internal class TypeDeclarationGenerator
             else AppendLine($"{names[i]},", 2);
         AppendLine("}", 1);
     }
-
-    private bool IsStructType () => type is { IsClass: false, IsEnum: false, IsValueType: true, IsPrimitive: false };
 
     private string GetNamespace (Type type)
     {


### PR DESCRIPTION
Hi!

This PR adds missing typescript declarations for C# structs and record structs.

I also extended CanCrawlCustomTypes test to check if DotNetJS can make TS definitions for record types (it's working, only for completeness).